### PR TITLE
Update terms link

### DIFF
--- a/src/pages/mint/index.js
+++ b/src/pages/mint/index.js
@@ -30,7 +30,6 @@ import {
 import collabStyles from '@components/collab/styles.module.scss'
 import classNames from 'classnames'
 import { CollabContractsOverview } from '../collaborate/tabs/manage'
-import { Link } from 'react-router-dom'
 
 const coverOptions = {
   quality: 0.85,

--- a/src/pages/mint/index.js
+++ b/src/pages/mint/index.js
@@ -635,7 +635,9 @@ export const Mint = () => {
 
       <Container>
         <Padding>
-          <Link to="/terms">Terms & Conditions</Link>
+          <Button href="https://github.com/teia-community/teia-docs/wiki/Core-Values-Code-of-Conduct-Terms-and-Conditions">
+            <Primary>Terms & Conditions</Primary>
+          </Button>
         </Padding>
       </Container>
       {/*       <BottomBanner>


### PR DESCRIPTION
Change the link to the terms & conditions, on the mint page, to https://github.com/teia-community/teia-docs/wiki/Core-Values-Code-of-Conduct-Terms-and-Conditions