### PR TITLE
fix: ⚡️ Jimmy two times

### DIFF
--- a/src/pages/objkt-display/tabs/swap.js
+++ b/src/pages/objkt-display/tabs/swap.js
@@ -142,9 +142,7 @@ export const Swap = ({
               <div className={styles.container}>
                 <p>
                   The Teia marketplace fee is temporarily set to 0%. Please
-                  consider donating to the address Please consider donating to
-                  teiaescrow.tez (tz1Q7fCeswrECCZthfzx2joqkoTdyin8DDg8) for
-                  maintenance funding.
+                  consider donating to teiaescrow.tez (tz1Q7fCeswrECCZthfzx2joqkoTdyin8DDg8) for maintenance funding.
                 </p>
               </div>
             </Padding>


### PR DESCRIPTION
Fixes  the duplicated sentence in the Swap warning message, IMO we should get rid of it entirely from the swap tab, but until this is decided here is the fixed version