### PR TITLE
hide-banned-objktcom-swaps-and-add-restricted-label

### DIFF
--- a/src/components/listings/index.js
+++ b/src/components/listings/index.js
@@ -4,7 +4,11 @@ import { Button, Primary, Purchase } from '../button'
 import { walletPreview } from '../../utils/string'
 import styles from './styles.module.scss'
 import { HicetnuncContext } from '../../context/HicetnuncContext'
-import { MarketplaceLabel, OBJKTLabel } from './marketplace-labels'
+import {
+  MarketplaceLabel,
+  OBJKTLabel,
+  RestrictedLabel,
+} from './marketplace-labels'
 
 function TeiaOrHenSwapRow({
   rowId,
@@ -40,6 +44,7 @@ function TeiaOrHenSwapRow({
         )}
       </div>
       <div className={styles.buttons}>
+        {(restricted || ban.includes(swap.creator_id)) && <RestrictedLabel />}
         <MarketplaceLabel swap={swap} />
         {!restricted && !ban.includes(swap.creator_id) && !isOwnSwap && (
           <Button
@@ -98,7 +103,7 @@ function TeiaOrHenSwapRow({
   )
 }
 
-function ObjktcomAskRow({ id, ask, onCollectClick }) {
+function ObjktcomAskRow({ id, ask, swap, restricted, ban, onCollectClick }) {
   return (
     <div className={styles.swap}>
       <div className={styles.issuer}>
@@ -111,10 +116,15 @@ function ObjktcomAskRow({ id, ask, onCollectClick }) {
       </div>
 
       <div className={styles.buttons}>
+        {(restricted || ban.includes(swap.creator_id)) && <RestrictedLabel />}
         <OBJKTLabel />
-        <Button onClick={() => onCollectClick()}>
-          <Purchase>Collect for {parseFloat(ask.price / 1000000)} tez</Purchase>
-        </Button>
+        {!restricted && !ban.includes(swap.creator_id) && (
+          <Button onClick={() => onCollectClick()}>
+            <Purchase>
+              Collect for {parseFloat(ask.price / 1000000)} tez
+            </Purchase>
+          </Button>
+        )}
       </div>
     </div>
   )
@@ -161,6 +171,9 @@ export const Listings = ({
               id={id}
               key={listing.key}
               ask={listing}
+              swap={listing}
+              restricted={restricted}
+              ban={ban}
               onCollectClick={() => {
                 handleCollectObjktcomAsk(listing)
               }}

--- a/src/components/listings/marketplace-labels/index.js
+++ b/src/components/listings/marketplace-labels/index.js
@@ -36,6 +36,14 @@ export const OBJKTLabel = () => (
     Objkt.com
   </span>
 )
+export const RestrictedLabel = () => (
+  <span
+    className={styles.swapLabel}
+    title="This swap is made by a restricted wallet."
+  >
+    Restricted
+  </span>
+)
 
 export const MarketplaceLabel = ({ swap }) => {
   if (swap.contract_address === MARKETPLACE_CONTRACT_TEIA) {


### PR DESCRIPTION
This PR addresses https://github.com/teia-community/teia-ui/issues/93 first of all, but also fixes a bug with restricted Objkt listings showing.

From this:
<img width="661" alt="image" src="https://user-images.githubusercontent.com/17555177/172928333-a22cad87-f36e-4bf3-96d5-461f5b669936.png">

To this:
<img width="678" alt="image" src="https://user-images.githubusercontent.com/17555177/172928278-38094722-edb7-4e24-8424-f12ccadf9441.png">
