### PR TITLE
quick fix: adjusting transfer error text

### DIFF
--- a/src/components/collab/show/Transfer.js
+++ b/src/components/collab/show/Transfer.js
@@ -96,7 +96,7 @@ export const Transfer = ({ id, creator, token_holders }) => {
       {tokenCount === 0 ? (
         <Padding>
           <div className={styles.container}>
-            <p>You do not have any editions available to transfer.</p>
+            <p>No editions found to transfer. This tool is only for sending OBJKTs from a collab contract to other tezos addresses, make sure to be signed into a collab contract to use it.</p>
           </div>
         </Padding>
       ) : (


### PR DESCRIPTION
since i dont know how to hide this tab when not in a collab i adjusted the warning text to explain that the transfer tab is only for sending objkts out of a collab contract. to avoid confusion