### PR TITLE
fix: ⚡️ husky on windows

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
+. "$(dirname -- "$0")/_/husky.sh"
 
-npx pretty-quick --staged --pattern "src/**/*.*(js|jsx|scss)"
+npx pretty-quick --staged


### PR DESCRIPTION
The arguments where not parsed properly on windows.
Using the package.json config instead works!