### PR TITLE
fix: ⚡️ feeds

### DIFF
--- a/src/components/collab/show/TxRow.js
+++ b/src/components/collab/show/TxRow.js
@@ -1,4 +1,4 @@
-import { Input } from '../../input'
+import { Input } from '@components/input'
 import styles from '../../collab/styles.module.scss'
 import { Button, Purchase, Secondary } from '../../button'
 import { CloseIcon } from '..'

--- a/src/components/identicons/index.js
+++ b/src/components/identicons/index.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import base from 'base-x'
 import styles from './styles.module.scss'
-import { CIDToURL } from '@utils'
+import { HashToURL } from '@utils'
 
 const alphabet58 = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz'
 const base58 = base(alphabet58)
@@ -41,8 +41,10 @@ function avatar(address) {
     xsb.push({ x, y, n })
   }
 
-  let path = 'M '
+  let path = ''
   let disk = false
+  if (xsb.length > 0) path += 'M '
+
   for (let i = 0; i < xsb.length; i++) {
     const n = xsb[i]
     if (newPath(path)) {
@@ -79,12 +81,13 @@ function avatar(address) {
           path += ` ${xsb[i + 2].x},${xsb[i + 2].y}`
         }
       }
-    } else if (!disk) {
-      path += ` ${n.x},${n.y}`
-      disk = false
     } else {
-      path += ` M ${n.x},${n.y}`
-      path += ` L ${n.x},${n.y}`
+      if (!disk) {
+        path += ` ${n.x},${n.y}`
+      } else {
+        path += ` M ${n.x},${n.y}`
+        path += ` L ${n.x},${n.y}`
+      }
       disk = false
     }
   }
@@ -292,7 +295,7 @@ export const Identicon = ({ address = '', logo }) => {
   if (logo) {
     return (
       <div className={styles.identicon}>
-        <img src={CIDToURL(logo.split('//')[1])} alt="identicon" />
+        <img src={HashToURL(logo)} alt="identicon" />
       </div>
     )
   }

--- a/src/components/input/index.js
+++ b/src/components/input/index.js
@@ -38,6 +38,7 @@ export const Input = ({
         onWheel={onWheel}
         onKeyPress={onKeyPress}
         autoFocus={autoFocus}
+        data-form-type="other"
       />
     </label>
     {children}

--- a/src/components/tags/index.js
+++ b/src/components/tags/index.js
@@ -7,46 +7,41 @@ import styles from './styles.module.scss'
 export const Tags = ({ token_tags, preview }) => {
   const context = useContext(HicetnuncContext)
 
-  console.debug(token_tags)
-  if (preview) {
-    return (
-      <div className={styles.container}>
-        {token_tags
-          .filter((e) => e !== '')
-          .map((tag, index) => {
-            return (
-              <Button
-                key={`tag${tag}${index}`}
-                to={`${PATH.TAGS}/${encodeURI(tag)}`}
+  return preview ? (
+    <div className={styles.container}>
+      {token_tags
+        .filter((e) => e !== '')
+        .map((tag, index) => {
+          return (
+            <Button
+              key={`tag${tag}${index}`}
+              to={`${PATH.TAGS}/${encodeURI(tag)}`}
+            >
+              <div className={styles.tag}>{tag}</div>
+            </Button>
+          )
+        })}
+    </div>
+  ) : (
+    <div className={styles.container}>
+      {token_tags
+        .filter((e) => e.tag.tag !== '')
+        .map((tag, index) => {
+          return (
+            <a
+              key={`tag${tag.tag.tag}${index}`}
+              href={`${PATH.TAGS}/${encodeURI(tag.tag.tag)}`}
+            >
+              <div
+                className={`${styles.tag} ${
+                  context.theme === 'light' ? styles.light : styles.dark
+                }`}
               >
-                <div className={styles.tag}>{tag}</div>
-              </Button>
-            )
-          })}
-      </div>
-    )
-  } else {
-    return (
-      <div className={styles.container}>
-        {token_tags
-          .filter((e) => e.tag.tag !== '')
-          .map((tag, index) => {
-            return (
-              <a
-                key={`tag${tag.tag.tag}${index}`}
-                href={`${PATH.TAGS}/${encodeURI(tag.tag.tag)}`}
-              >
-                <div
-                  className={`${styles.tag} ${
-                    context.theme === 'light' ? styles.light : styles.dark
-                  }`}
-                >
-                  {tag.tag.tag}
-                </div>
-              </a>
-            )
-          })}
-      </div>
-    )
-  }
+                {tag.tag.tag}
+              </div>
+            </a>
+          )
+        })}
+    </div>
+  )
 }

--- a/src/pages/display/index.js
+++ b/src/pages/display/index.js
@@ -215,7 +215,7 @@ export default class Display extends Component {
     claim: [],
   }
 
-  componentWillMount = async () => {
+  componentDidMount = async () => {
     const id = window.location.pathname.split('/')[1]
     // console.log(window.location.pathname.split('/'))
 

--- a/src/pages/display/index.js
+++ b/src/pages/display/index.js
@@ -272,7 +272,6 @@ export default class Display extends Component {
           subjkt: window.location.pathname.split('/')[1],
         })
         const resTz = await fetchTz(this.state.wallet)
-        console.debug(resTz)
         this.setState({ hdao: Math.floor(resTz[0].hdao_balance / 1000000) })
       } else {
         this.props.history.push('/')

--- a/src/pages/display/index.js
+++ b/src/pages/display/index.js
@@ -16,7 +16,7 @@ import { CollabsTab } from '@components/collab/show/CollabsTab'
 import styles from './styles.module.scss'
 import { getWalletBlockList, getUnderReviewList, getNsfwList } from '@constants'
 import { IconCache } from '@utils/with-icon'
-import { CIDToURL } from '@utils'
+import { HashToURL } from '@utils'
 const axios = require('axios')
 
 const urlParameters = new URLSearchParams(window.location.search)
@@ -241,7 +241,7 @@ export default class Display extends Component {
       try {
         if (res[0]) {
           const meta = await axios
-            .get(CIDToURL(res[0].metadata_file.split('//')[1]))
+            .get(HashToURL(res[0].metadata_file))
             .then((res) => res.data)
 
           if (meta.description) this.setState({ description: meta.description })
@@ -257,13 +257,11 @@ export default class Display extends Component {
       const res = await fetchSubjkts(
         decodeURI(window.location.pathname.split('/')[1])
       )
-      // console.log(decodeURI(window.location.pathname.split('/')[1]))
-      console.debug(res)
       if (res[0]?.metadata_file) {
         const meta = await axios
-          .get(CIDToURL(res[0].metadata_file.split('//')[1]))
+          .get(HashToURL(res[0].metadata_file))
           .then((res) => res.data)
-        console.debug(meta)
+
         if (meta.description) this.setState({ description: meta.description })
         if (meta.identicon) this.setState({ identicon: meta.identicon })
       }
@@ -290,7 +288,7 @@ export default class Display extends Component {
       })
     }
     this.onReady()
-    console.debug(await fetchBalance(this.state.wallet))
+
     this.setState({ claim: await fetchBalance(this.state.wallet) })
     //.reduce((a, b) => a + b, 0)
   }

--- a/src/pages/search/index.js
+++ b/src/pages/search/index.js
@@ -196,7 +196,7 @@ async function fetchSales(offset) {
   const { errors, data } = await fetchGraphQL(
     `
   query sales {
-    trade(order_by: {timestamp: desc}, limit : ${FETCH_BATCH}, offset : ${offset}, where: {swap: {price: {_gte: "0"}}}) {
+    trade(order_by: {timestamp: desc}, limit : ${FETCH_BATCH}, offset : ${offset}) {
       timestamp
       swap {
         price

--- a/src/pages/search/index.js
+++ b/src/pages/search/index.js
@@ -345,8 +345,11 @@ export class Search extends Component {
   }
 
   update = async (e, reset) => {
-    const arr = getWalletBlockList()
+    const bans = getWalletBlockList()
 
+    const filterBan = (e) => {
+      return !bans.includes(e.creator_id)
+    }
     this.setState({ select: e })
     if (reset) {
       this.setState({
@@ -360,7 +363,7 @@ export class Search extends Component {
       let res = await fetchFeed(
         Number(this.state.search) + 1 - this.state.offset
       )
-      res = res.filter((e) => !arr.includes(e.creator_id))
+      res = res.filter(filterBan)
       this.setState({
         feed: [...this.state.feed, ...res],
       })
@@ -395,7 +398,7 @@ export class Search extends Component {
 
     if (e === '🏳️‍🌈 tezospride') {
       let res = await fetchTag('tezospride', this.state.offset)
-      res = res.filter((e) => !arr.includes(e.creator_id))
+      res = res.filter(filterBan)
       this.setState({
         feed: _.uniqBy([...this.state.feed, ...res], 'creator_id'),
       })
@@ -403,7 +406,7 @@ export class Search extends Component {
 
     if (e === 'html/svg') {
       let res = await fetchInteractive(this.state.offset)
-      res = res.filter((e) => !arr.includes(e.creator_id))
+      res = res.filter(filterBan)
       this.setState({
         feed: _.uniqBy([...this.state.feed, ...res], 'creator_id'),
       })
@@ -421,7 +424,7 @@ export class Search extends Component {
     }
     if (e === 'random') {
       let res = await fetchRandomObjkts(15)
-      res = res.filter((e) => !arr.includes(e.creator_id))
+      res = res.filter(filterBan)
       this.setState({ feed: [...this.state.feed, ...res] })
     }
 
@@ -439,7 +442,7 @@ export class Search extends Component {
         this.state.search,
         this.state.feed[this.state.feed.length - 1].id
       )
-      res = res.filter((e) => !arr.includes(e.creator_id))
+      res = res.filter(filterBan)
       this.setState({
         feed: _.uniqBy([...this.state.feed, ...res], 'creator_id'),
       })
@@ -448,7 +451,7 @@ export class Search extends Component {
     if (e === 'recent sales') {
       let tokens = await fetchSales(this.state.offset)
       tokens = tokens.map((e) => e.token)
-      tokens = tokens.filter((e) => !arr.includes(e.creator_id))
+      tokens = tokens.filter(filterBan)
       this.setState({
         feed: _.uniqBy([...this.state.feed, ...tokens], 'id'),
       })
@@ -456,12 +459,9 @@ export class Search extends Component {
 
     if (e === 'new OBJKTs') {
       let tokens = await fetchFeed(this.state.lastId, this.state.offset)
-      tokens = tokens.filter((e) => !arr.includes(e.creator_id))
+      tokens = tokens.filter(filterBan)
       this.setState({
-        feed: _.uniqBy(
-          _.uniqBy([...this.state.feed, ...tokens], 'id'),
-          'creator_id'
-        ),
+        feed: [...this.state.feed, ...tokens],
       })
     }
 


### PR DESCRIPTION
This closes #110
Reasoning is simple, if 15 operation by the same creator or on the same token (depending on the feed) it would break the infinite scroll.
This PR:
- bumps the batch items count 40
- Don't uniq creators in `recent sales`, IMO a single creator can sell multiple tokens I don't see why we should filter that? Still doing uniq by ID to not have duplicate tokens.
- Completely stops uniq on `new OBJKT`