### PR TITLE
fix: ⚡️ root is a directory detection

### DIFF
--- a/src/utils/html.js
+++ b/src/utils/html.js
@@ -53,7 +53,10 @@ export async function unzipBuffer(buffer) {
   for (const entry of entries) {
     const filename = entry.path.replace(/^.*[\\/]/, '')
     if (filename === 'index.html') {
-      rootDir = entry.path.match(/.*\//) || '/'
+      const matchRoot = entry.path.match(/.*\//) || '/'
+      if (matchRoot.length > 0) {
+        rootDir = matchRoot[0]
+      }
       break
     }
   }
@@ -67,7 +70,7 @@ export async function unzipBuffer(buffer) {
   // Create files map
   const files = {}
   entries.forEach((entry, index) => {
-    const relPath = entry.path.replace(`${rootDir}/`, '')
+    const relPath = entry.path.replace(`${rootDir}`, '')
     console.debug('Entry relPath: ', relPath)
     let type
     if (entry.buffer.length === 0 && entry.path.endsWith('/')) {


### PR DESCRIPTION
This allows user to provide a zip whose root is a folder, both options would be valid:
<img src="https://user-images.githubusercontent.com/7041726/185692488-c2c9e741-237b-42b1-860c-03d2f2c273b5.png" width=350/>
<img src="https://user-images.githubusercontent.com/7041726/185692508-d4d91511-4ff0-42b6-8e73-dd39bdab71b4.png" width=350/>
