### PR TITLE
fix: 📃 link to T&C restriction document

### DIFF
--- a/src/pages/objkt-display/index.js
+++ b/src/pages/objkt-display/index.js
@@ -207,7 +207,7 @@ export const ObjktDisplay = () => {
                     </a>{' '}
                     to resolve the status. See the{' '}
                     <a
-                      href="https://github.com/teia-community/teia-docs/wiki/Core-Values-Code-of-Conduct-Terms-and-Conditions#3-terms-and-conditions---account-restrictions"
+                      href="https://github.com/teia-community/teia-docs/wiki/Core-Values-Code-of-Conduct-Terms-and-Conditions#content-moderation"
                       target="_blank"
                       rel="noreferrer"
                     >


### PR DESCRIPTION
same as about page: a link update is needed since the last TOC update on the wiki (subtitles needed to be changed)
sorry