### PR TITLE
Also render previews for /profilename/collabs and /profilename/collection

### DIFF
--- a/.github/workflows/nginx.conf
+++ b/.github/workflows/nginx.conf
@@ -46,14 +46,14 @@ server {
     proxy_ssl_server_name on;
     proxy_pass_request_headers off;
 
-    location /teztok/ {
+    location ^~ /teztok/ {
         internal; # Specifies that a given location can only be used for internal requests
         proxy_set_header Content-Type "application/json";
         proxy_set_header Accept "application/json";
         proxy_pass https://teztok.teia.rocks/; # trailing slash
     }
 
-    location /teia/ {
+    location ^~ /teia/ {
         internal;
         proxy_pass http://localhost:8080/; # trailing slash
     }
@@ -74,7 +74,7 @@ server {
         include /header.conf;
     }
 
-    location ~ "^/([0-9a-zA-Z\-_\ ]+)$" {
+    location ~ "^/([0-9a-zA-Z\-_\ ]+)" {
         default_type  text/html;
         header_filter_by_lua_block { ngx.header.content_length = nil }
         content_by_lua_block {
@@ -106,9 +106,9 @@ server {
         include /header.conf;
     }
 
-    location /static {}
-    location /assets {}
-    location /icons {
+    location ^~ /static/ {}
+    location ^~ /assets/ {}
+    location ^~ /icons/ {
         default_type  application/json;
     }
 }


### PR DESCRIPTION
I forgot the collection and collab paths, for example `https://teia.art/chemicalmessiah/collection?collections=320` preview is broken now. This commit fixes that. :pray: 