### PR TITLE
fix: 🐛 nginx location regex order

### DIFF
--- a/.github/workflows/nginx.conf
+++ b/.github/workflows/nginx.conf
@@ -74,7 +74,7 @@ server {
         include /header.conf;
     }
 
-    location ~ "^/([0-9a-zA-Z\-_\ ]+)" {
+    location ~ "^/tz/(tz[a-zA-Z0-9]{34})" {
         default_type  text/html;
         header_filter_by_lua_block { ngx.header.content_length = nil }
         content_by_lua_block {
@@ -90,7 +90,7 @@ server {
         include /header.conf;
     }
 
-    location ~ "^/tz/(tz[a-zA-Z0-9]{34})" {
+    location ~ "^/([0-9a-zA-Z\-_\ ]+)" {
         default_type  text/html;
         header_filter_by_lua_block { ngx.header.content_length = nil }
         content_by_lua_block {


### PR DESCRIPTION
I broke the /tz/address preview last time :sweat_smile: I forgot nginx goes in order of locations top to bottom, and not in in length (like traefik)