### PR TITLE
fix: 🐛 nginx config username can also contain dots

### DIFF
--- a/.github/workflows/nginx.conf
+++ b/.github/workflows/nginx.conf
@@ -90,7 +90,7 @@ server {
         include /header.conf;
     }
 
-    location ~ "^/([0-9a-zA-Z\-_\ ]+)" {
+    location ~ "^/([0-9a-zA-Z\-_\ \.]+)" {
         default_type  text/html;
         header_filter_by_lua_block { ngx.header.content_length = nil }
         content_by_lua_block {


### PR DESCRIPTION
Right now the previews aren't being triggered for https://teia.art/Generative.Hut/collection
This commit fixes the regex to also include dots