### PR TITLE
fix: :bug:  zalgo regex replaces

### DIFF
--- a/.github/workflows/Dockerfile
+++ b/.github/workflows/Dockerfile
@@ -10,6 +10,7 @@ RUN : \
 
 FROM openresty/openresty:alpine
 EXPOSE 80
+RUN mkdir /lua; wget -O /lua/ustring.lua https://raw.githubusercontent.com/wikimedia/mediawiki-extensions-Scribunto/master/includes/Engines/LuaCommon/lualib/ustring/ustring.lua
 COPY .github/workflows/nginx.conf /etc/nginx/conf.d/default.conf
 COPY .github/workflows/previews.lua /lua/previews.lua
 COPY --from=builder /usr/src/app/build/ /usr/local/openresty/nginx/html/

--- a/.github/workflows/previews.lua
+++ b/.github/workflows/previews.lua
@@ -57,7 +57,11 @@ function _M.injectOpenGraphTags(body, info)
         '<meta name="twitter:image" content="' .. info['image'] .. '" />'
     
     openGraphTags = ngx.re.gsub(openGraphTags, 'ipfs://', 'https://cache.teia.rocks/ipfs/')
-    return ngx.re.gsub(body, '<head>', '<head>' .. openGraphTags)
+    local ok, content = pcall(ngx.re.gsub, body, '<head>', '<head>' .. openGraphTags)
+    if ok and content then
+        return content
+    end
+    return body
 end
 
 return _M

--- a/.github/workflows/previews.lua
+++ b/.github/workflows/previews.lua
@@ -1,5 +1,6 @@
 local _M = {}
 local cjson = require "cjson"
+local ustring = require "ustring"
 
 function _M.clean(input)
     return ngx.re.gsub(input, '"', '')
@@ -57,7 +58,7 @@ function _M.injectOpenGraphTags(body, info)
         '<meta name="twitter:image" content="' .. info['image'] .. '" />'
     
     openGraphTags = ngx.re.gsub(openGraphTags, 'ipfs://', 'https://cache.teia.rocks/ipfs/')
-    local ok, content = pcall(ngx.re.gsub, body, '<head>', '<head>' .. openGraphTags)
+    local ok, content = pcall(ustring.gsub, body, '<head>', '<head>' .. openGraphTags)
     if ok and content then
         return content
     end


### PR DESCRIPTION
Fixes the preview for tokens with weird characters in the name or description, for example: https://teia.art/objkt/814116