### PR TITLE
docs: 📝 collab message for non managers

### DIFF
--- a/src/pages/collaborate/manage.jsx
+++ b/src/pages/collaborate/manage.jsx
@@ -130,7 +130,7 @@ export const CollabContractsOverview = ({ showAdminOnly = false }) => {
         <p>
           {loadingCollabs
             ? 'Looking for collabs...'
-            : 'You aren’t part of any collaborations at the moment'}
+            : 'You are not a manager of any collaborations at the moment'}
         </p>
       )}
     </Container>


### PR DESCRIPTION
This original message:
> You aren’t part of any collaborations at the moment

was confusing, because the user may be a member of collabs, but not a manager of those contracts.

The new message makes it clear:
> You are not a manager of any collaborations at the moment