### PR TITLE
feat: Preconnect to lists.teia.art and imgproxy.teia.rocks

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,6 +30,7 @@
     />
     <link rel="shortcut icon" href="/icons/favicon.ico?v=1" />
     <link rel="preconnect" href="https://cache.teia.rocks" />
+    <link rel="preconnect" href="https://imgproxy.teia.rocks" />
     <link rel="preconnect" href="https://lists.teia.art" />
     <link rel="preconnect" href="https://raw.githubusercontent.com" />
     <meta name="build-commit" content="<%=BUILD_COMMIT%>" />

--- a/index.html
+++ b/index.html
@@ -30,6 +30,7 @@
     />
     <link rel="shortcut icon" href="/icons/favicon.ico?v=1" />
     <link rel="preconnect" href="https://cache.teia.rocks" />
+    <link rel="preconnect" href="https://lists.teia.art" />
     <link rel="preconnect" href="https://raw.githubusercontent.com" />
     <meta name="build-commit" content="<%=BUILD_COMMIT%>" />
     <meta name="msapplication-TileColor" content="#ffc40d" />


### PR DESCRIPTION
I noticed only cache.teia.rocks and raw.githubusercontent.com were in the list. Every full pageload needs multiple requests to lists.teia.art, so it might be a good idea to also preconnect it?