### PR TITLE
fix: use default ipfs context root for the CDN

### DIFF
--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -51,9 +51,7 @@ const CIDToURL = (
 
   switch (type) {
     case 'CDN':
-      return `https://cache.teia.rocks/media/${
-        options.size || 'raw'
-      }/ipfs/${cid}`
+      return `https://cache.teia.rocks/ipfs/${cid}`
     case 'CLOUDFLARE':
       return `https://cloudflare-ipfs.com/ipfs/${cid}`
     case 'PINATA':


### PR DESCRIPTION
There's probably some more code cleanup needed from our experiments with the tcinfra thumbnail generator.