### PR TITLE
Increases the default storage fee to 400

### DIFF
--- a/src/context/userStore.ts
+++ b/src/context/userStore.ts
@@ -472,7 +472,7 @@ export const useUserStore = create<UserState>()(
               'Claim DAO tokens',
               'Sorry, but you already claimed all your tokens'
             )
-            return
+            //return
           }
 
           step(
@@ -488,7 +488,10 @@ export const useUserStore = create<UserState>()(
               userMerkleData.leafDataPacked
             )
 
-            return await handleOp(batch, 'Claim DAO tokens')
+            return await handleOp(batch, 'Claim DAO tokens', {
+              amount: 0,
+              storageLimit: 400,
+            })
           } catch (e) {
             showError('Claim DAO tokens', e)
           }

--- a/src/context/userStore.ts
+++ b/src/context/userStore.ts
@@ -472,7 +472,7 @@ export const useUserStore = create<UserState>()(
               'Claim DAO tokens',
               'Sorry, but you already claimed all your tokens'
             )
-            //return
+            return
           }
 
           step(


### PR DESCRIPTION
Some claim operations fail because the storage fees set by the wallets are too low. I added a default storage fee to the claim operation to try to fix it.