### PR TITLE
fix: remove some access logging for internal calls

### DIFF
--- a/.github/workflows/nginx.conf
+++ b/.github/workflows/nginx.conf
@@ -161,6 +161,7 @@ server {
     listen 8080;
     root /usr/local/openresty/nginx/html;
     include /header.conf;
+    access_log    off;
     location / {
         include /header.conf;
         try_files $uri $uri/ /index.html =404;
@@ -171,6 +172,7 @@ server {
     listen 127.0.0.1:8081;
     proxy_ssl_server_name on;
     proxy_pass_request_headers off;
+    access_log    off;
 
     location / {
         proxy_set_header Content-Type "application/json";
@@ -183,6 +185,7 @@ server {
     listen 127.0.0.1:8082;
     proxy_ssl_server_name on;
     proxy_pass_request_headers off;
+    access_log    off;
 
     location / {
         proxy_set_header Content-Type "application/json";
@@ -195,6 +198,7 @@ server {
     listen 127.0.0.1:8083;
     proxy_ssl_server_name on;
     proxy_pass_request_headers off;
+    access_log    off;
 
     location / {
         proxy_set_header Content-Type "application/json";
@@ -207,6 +211,7 @@ server {
     listen 127.0.0.1:8084;
     proxy_ssl_server_name on;
     proxy_pass_request_headers off;
+    access_log    off;
 
     location / {
         proxy_set_header Content-Type "application/json";


### PR DESCRIPTION
Sorry, I forgot I don't care about the rpc healthcheck log calls :sweat_smile: 
This is a minor fix, not urgent at all