### PR TITLE
fix: avoid out of memory when minting large files

### DIFF
--- a/src/components/form/MintForm.jsx
+++ b/src/components/form/MintForm.jsx
@@ -29,6 +29,8 @@ export default function MintForm() {
           .show(`File too big: ${data.artifact.file.size / 1e6}mb`)
         return
       }
+      const URL = window.URL || window.webkitURL
+      data.artifact.reader = URL.createObjectURL(data.artifact.file)
     }
     useMintStore.setState({ ...data, isValid: true })
     navigate('preview')

--- a/src/pages/mint/fields.js
+++ b/src/pages/mint/fields.js
@@ -141,7 +141,7 @@ export const fields = [
     type: 'file',
     watch: true,
     rules: {
-      required: 'No file selected',
+      required: 'You did not select a valid file',
     },
   },
   {


### PR DESCRIPTION
I tried to fix the out of memory bug from #280 with the suggestion @melMass posted. I don't know if I implemented it correctly tough. It seems to work as expected.