### PR TITLE
fix: avoid uploading gif files twice

### DIFF
--- a/src/data/ipfs.ts
+++ b/src/data/ipfs.ts
@@ -224,7 +224,17 @@ export const prepareFile = async ({
 
   // upload thumbnail image
   let thumbnailUri = IPFS_DEFAULT_THUMBNAIL_URI
-  if (thumbnail) {
+  if(thumbnail && thumbnail.file?.type == 'image/gif') {
+    console.debug('GIF format detected, use the same cid for thumbnail to avoid uploading again')
+    thumbnailUri = `${uri}`
+    if (thumbnail?.format) {
+      const format = JSON.parse(JSON.stringify(thumbnail.format))
+      format.uri = thumbnailUri
+      format.fileName = `thumbnail_${format.fileName}`
+      formats.push(format)
+      console.debug('thumbnail format', format)
+    }
+  } else if (thumbnail) {
     const thumbnailCid = await uploadFileToIPFSProxy({
       blob: new Blob([thumbnail.buffer]),
       path: `thumbnail_${

--- a/src/data/ipfs.ts
+++ b/src/data/ipfs.ts
@@ -224,8 +224,10 @@ export const prepareFile = async ({
 
   // upload thumbnail image
   let thumbnailUri = IPFS_DEFAULT_THUMBNAIL_URI
-  if(thumbnail && thumbnail.file?.type == 'image/gif') {
-    console.debug('GIF format detected, use the same cid for thumbnail to avoid uploading again')
+  if (thumbnail && thumbnail.file?.type === 'image/gif') {
+    console.debug(
+      'GIF format detected, use the same cid for thumbnail to avoid uploading again'
+    )
     thumbnailUri = `${uri}`
     if (thumbnail?.format) {
       const format = JSON.parse(JSON.stringify(thumbnail.format))

--- a/src/data/ipfs.ts
+++ b/src/data/ipfs.ts
@@ -226,7 +226,7 @@ export const prepareFile = async ({
   let thumbnailUri = IPFS_DEFAULT_THUMBNAIL_URI
   if (thumbnail && thumbnail.file?.type === 'image/gif') {
     console.debug(
-      'GIF format detected, use the same cid for thumbnail to avoid uploading again'
+      "GIF format detected, we will use the artifact's cid as the thumbnail to avoid uploading twice"
     )
     thumbnailUri = `${uri}`
     if (thumbnail?.format) {


### PR DESCRIPTION
There's no thumbnail for gif files, so avoid the second upload and reuse the same cid as the original.
Possible fix for https://github.com/teia-community/teia-ui/issues/278

//edit: thumbnails are managed by imgproxy anyway