### PR TITLE
fix: run build command

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -137,6 +137,9 @@ export default defineConfig(({ mode }) => {
       port: 3000,
     },
     build: {
+      commonjsOptions: {
+        transformMixedEsModules: true
+      },
       outDir: 'build',
       sourcemap: !prod,
       rollupOptions: {


### PR DESCRIPTION
I was getting "Uncaught ReferenceError: require is not defined" applying this to vite.config seems to fix it

This is important because we do not use the builtin webserver to display the UI.

I found the solution on https://github.com/vitejs/vite/issues/3409#issuecomment-1138202247