### PR TITLE
fix issue #387 collected items for sale visibility

### DIFF
--- a/src/pages/profile/collections.jsx
+++ b/src/pages/profile/collections.jsx
@@ -8,8 +8,7 @@ import { BaseTokenFieldsFragment } from '@data/api'
 import { useOutletContext } from 'react-router'
 
 const FILTER_ALL = 'ALL'
-const FILTER_FOR_SALE = 'FOR_SALE'
-const FILTER_NOT_FOR_SALE = 'NOT_FOR_SALE'
+const FILTER_COLLECTED = 'FILTER_COLLECTED';
 
 export default function Collections() {
   const { showFilters, showRestricted, overrideProtections, user_address } =
@@ -25,8 +24,7 @@ export default function Collections() {
           onChange={setFilter}
           items={[
             { type: FILTER_ALL, label: 'All' },
-            { type: FILTER_FOR_SALE, label: 'For sale' },
-            { type: FILTER_NOT_FOR_SALE, label: 'Not for sale' },
+            { type: FILTER_COLLECTED, label: 'Collected' },
           ]}
         />
       )}
@@ -42,21 +40,19 @@ export default function Collections() {
         maxItems={null}
         postProcessTokens={(tokens) => {
           switch (filter) {
-            case FILTER_FOR_SALE:
+            // Return all tokens that the user has collected but not created.
+            // We used to FILTER_FOR_SALE and FILTER_NOT_FOR_SALE but no
+            // reason for that. We want to see all items a user has collected
+            // but not created here.  Users who wish to sell a token that
+            // they have collected should still see it on their collections
+            // page until it has been sold and would then not match the
+            // user_address.
+            case FILTER_COLLECTED:
               return tokens.filter(
-                ({ listing_seller_address }) =>
-                  listing_seller_address === user_address
+                ({ artist_address }) => artist_address !== user_address
               )
-
-            case FILTER_NOT_FOR_SALE:
-              return tokens.filter(
-                ({ listing_seller_address, artist_address }) =>
-                  artist_address !== user_address &&
-                  listing_seller_address !== user_address
-              )
-
             default:
-              return tokens
+              return tokens;
           }
         }}
         extractTokensFromResponse={(data, { postProcessTokens }) => {

--- a/src/pages/profile/collections.jsx
+++ b/src/pages/profile/collections.jsx
@@ -8,7 +8,7 @@ import { BaseTokenFieldsFragment } from '@data/api'
 import { useOutletContext } from 'react-router'
 
 const FILTER_ALL = 'ALL'
-const FILTER_COLLECTED = 'FILTER_COLLECTED';
+const FILTER_COLLECTED = 'FILTER_COLLECTED'
 
 export default function Collections() {
   const { showFilters, showRestricted, overrideProtections, user_address } =
@@ -52,7 +52,7 @@ export default function Collections() {
                 ({ artist_address }) => artist_address !== user_address
               )
             default:
-              return tokens;
+              return tokens
           }
         }}
         extractTokensFromResponse={(data, { postProcessTokens }) => {


### PR DESCRIPTION
As mentioned in issue #387, @Zir0h pointed out where in the code this was likely happening. I read through the code for the collections page and could not understand the need to filter on FILTER_FOR_SALE and FILTER_NOT_FOR_SALE as it didn't align with the functionality we wanted for the page. The main goal here is to display all items a collector has acquired, irrespective of whether these items are currently listed for sale or not. This ensures a more consistent and user-friendly experience, where collectors can view their entire collection in one place.

In this pull request, I have removed the FILTER_FOR_SALE and FILTER_NOT_FOR_SALE filters and replaced them with a single FILTER_COLLECTED filter. This new filter effectively shows all tokens collected by the user that they didn't create themselves. The change simplifies the filtering logic and aligns the collections page with the intended purpose of showcasing all acquired items, making it easier for users to manage and view their collections.

This update should resolve the issue where tokens disappeared from the collection upon being listed for sale, as now all collected items remain visible regardless of their sale status.  I'm not that good at JavaScript though, so someone should review this for any syntax issue.