### PR TITLE
fix: use imgproxy for farcaster urls

### DIFF
--- a/docker/previews.lua
+++ b/docker/previews.lua
@@ -24,7 +24,7 @@ end
 function _M.findTokenDetails(search)
     local res = ngx.location.capture('/teztok/v1/graphql', {
         method = ngx.HTTP_POST,
-        body = '{"query":"query findTokenDetails {  token: tokens_by_pk(token_id: \\"'.. search .. '\\", fa2_address: \\"KT1RJ6PbjHpwc3M5rw5s2Nbmefwbuwbdxton\\") { token_id name description display_uri artifact_uri artist_address}}"}',
+        body = '{"query":"query findTokenDetails {  token: tokens_by_pk(token_id: \\"'.. search .. '\\", fa2_address: \\"KT1RJ6PbjHpwc3M5rw5s2Nbmefwbuwbdxton\\") { token_id name description display_uri artifact_uri artist_address teia_meta { preview_uri }}}"}',
     })
     -- ngx.log(ngx.ERR, "findTokenDetails: ", res.body)
     data = cjson.decode(res.body)['data']['token']
@@ -34,6 +34,7 @@ function _M.findTokenDetails(search)
     token['description'] = _M.clean(data['description'])
     token['image'] = (data['display_uri'] ~= ngx.null and _M.clean(data['display_uri']) or _M.clean(data['artifact_uri']))
     token['artist_address'] = data['artist_address']
+    token['preview_uri'] = data['teia_meta']['preview_uri']
     return token
 end
 
@@ -59,7 +60,7 @@ function _M.injectOpenGraphTags(body, info)
         '<meta name="twitter:description" content="' .. info['description'] .. '" />' ..
         '<meta name="twitter:image" content="' .. info['image'] .. '" />' ..
         '<meta property="fc:frame" content="vNext"/>' ..
-        '<meta property="fc:frame:image" content="' .. info['image'] .. '"/>' ..
+        '<meta property="fc:frame:image" content="https://imgproxy.teia.art' .. info['preview_uri'] .. '"/>' ..
         '<meta property="fc:frame:image:aspect_ratio" content="1:1"/>' ..
         '<meta name="fc:frame:button:1" content="Buy on Teia"/>' ..
         '<meta name="fc:frame:button:1:action" content="link"/>' ..


### PR DESCRIPTION
they don't mind webp and it's possible larger images are blocked because of their 10MB restriction
for example:

https://teia.art/objkt/127453
validateFrameEmbed 400 - Frame image error: HTTPError: Response code 403 (Response size must be under 10MB)