### PR TITLE
disable mp4 covers for now

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -110,7 +110,6 @@ export const ALLOWED_COVER_MIMETYPES = [
   MIMETYPE.JPEG,
   MIMETYPE.PNG,
   MIMETYPE.GIF,
-  MIMETYPE.MP4,
 ]
 
 export const AUTO_GENERATE_COVER_MIMETYPES = [
@@ -119,7 +118,7 @@ export const AUTO_GENERATE_COVER_MIMETYPES = [
   'audio/mid'
 ]
 
-export const ALLOWED_COVER_FILETYPES_LABEL = 'jpeg, png, gif, mp4'
+export const ALLOWED_COVER_FILETYPES_LABEL = 'jpeg, png, gif'
 export const MAX_EDITIONS = 10000 // Limited by contract
 export const MIN_ROYALTIES = 10
 export const MAX_ROYALTIES = 25


### PR DESCRIPTION
mp4 cover images don't actually work, and this causes annoying errors for artists (see #447 )