### PR TITLE
[Feature✨] Add curation tab to user profile

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -57,6 +57,7 @@ import Display from '@pages/profile'
 import Collections from '@pages/profile/collections'
 import Creations from '@pages/profile/creations'
 import Collabs from '@pages/profile/collabs'
+import Curation from '@pages/profile/curation'
 
 import Sync from '@pages/sync'
 import { Terms } from '@pages/terms'
@@ -83,6 +84,7 @@ const display_routes = (
   <>
     <Route index element={<Creations />} />
     <Route exact path="collection" element={<Collections />} />
+    <Route exact path="curation" element={<Curation />} />
     <Route exact path="collabs" element={<Collabs />} />
   </>
 )

--- a/src/pages/profile/curation.jsx
+++ b/src/pages/profile/curation.jsx
@@ -1,0 +1,49 @@
+import { gql } from 'graphql-request'
+import TokenCollection from '@atoms/token-collection'
+import { BaseTokenFieldsFragment } from '@data/api'
+import { useOutletContext } from 'react-router'
+
+export default function Curation() {
+  const { showRestricted, overrideProtections, address } = useOutletContext()
+
+  return (
+    <TokenCollection
+      showRestricted={showRestricted}
+      overrideProtections={overrideProtections}
+      label="Artist's Curation"
+      namespace="curation"
+      swrParams={[address]}
+      variables={{ address }}
+      emptyMessage="no curated tokens"
+      maxItems={null}
+      extractTokensFromResponse={(data) => {
+        return data.listings.map(({ token, seller_address }) => ({
+          ...token,
+          listing_seller_address: seller_address,
+          key: token.token_id,
+        }))
+      }}
+      query={gql`
+        ${BaseTokenFieldsFragment}
+        query curatorGallery($address: String!) {
+          listings(
+            where: {
+              token: { artist_address: { _neq: $address } }
+              seller_address: { _eq: $address }
+              status: { _eq: "active" }
+            }
+            distinct_on: token_id
+          ) {
+            seller_address
+            token {
+              ...baseTokenFields
+            }
+            contract_address
+            amount_left
+            price
+          }
+        }
+      `}
+    />
+  )
+}

--- a/src/pages/profile/index.jsx
+++ b/src/pages/profile/index.jsx
@@ -124,6 +124,7 @@ export default function Display() {
   const TABS = [
     { title: 'Creations', to: '' },
     { title: 'Collection', to: 'collection' },
+    { title: 'Curation', to: 'curation' },
     { title: 'Collabs', to: 'collabs' },
   ]
 


### PR DESCRIPTION
## Summary
- list curated tokens a user is reselling
- expose new page from profile tabs and routing

I used ChatGPT Codex to generate the code.  I rebuilt my container using the branch and checked locally, it seems to work: 

![Screenshot from 2025-05-20 23-02-28](https://github.com/user-attachments/assets/d1b396fb-f457-48c9-98d4-41bee6196bff)

These are NFTs I've collected, am not the owner of, and offering for sale.  I've mentioned adding this feature to @Zir0h in the feature request channel a while ago.  