### PR TITLE
fix: show all items in dropdown in the same style

### DIFF
--- a/src/components/header/events/EventCard.jsx
+++ b/src/components/header/events/EventCard.jsx
@@ -37,12 +37,12 @@ export const EventCard = ({ event }) => {
             )}
           </Button>
         ) : (
-          <>
+          <Button>
             {event.title}
             {event.icon && (
               <span className={styles.event_icon}>{event.icon}</span>
             )}
-          </>
+          </Button>
         )}
       </motion.h1>
       <motion.p variants={itemVariants} className={styles.event_tag_line}>


### PR DESCRIPTION
Maybe fix for:
![2025-05-25-230412_774x512_scrot](https://github.com/user-attachments/assets/9330eb6e-3c81-4e52-9cd2-18cec5e51cfc)
?