### PR TITLE
Validate that customRpcNode is a string before setting it ✨

### DIFF
--- a/src/context/localSettingsStore.ts
+++ b/src/context/localSettingsStore.ts
@@ -116,9 +116,10 @@ export const useLocalSettings = create<LocalSettingsState>()(
           return rpcNode
         },
         setCustomRpcNode: (customRpcNode: string) => {
-          if (!customRpcNode) {
+          if (!customRpcNode || typeof customRpcNode !== 'string') {
             return
           }
+
           if (!customRpcNode.startsWith('http')) {
             customRpcNode = `https://${customRpcNode}`
           }


### PR DESCRIPTION
<img width="479" height="206" alt="image" src="https://github.com/user-attachments/assets/14eb0579-9c1a-4816-8b47-08b5450410e9" />

In the production version, setting a custom RPC is not possible due to an "Uncaught TypeError", this fixes it.  💘

How to reproduce the problem:
1. Go to [settings](https://teia.art/settings)
2. Try setting a custom RPC.

