### PR TITLE
fix: accessibility Blog / Post Focus Styling

### DIFF
--- a/src/atoms/tab/index.module.scss
+++ b/src/atoms/tab/index.module.scss
@@ -16,6 +16,12 @@
     margin-bottom: -1px;
     border-bottom: 1px solid var(--gray-60);
   }
+
+  &:focus-visible {
+    outline: 2px solid var(--text-color);
+    outline-offset: 2px;
+    border-radius: 2px;
+  }
 }
 
 .tabs {

--- a/src/components/markdown/index.module.scss
+++ b/src/components/markdown/index.module.scss
@@ -8,6 +8,12 @@
 
   a {
     font-weight: 700;
+
+    &:focus-visible {
+      outline: 2px solid var(--text-color);
+      outline-offset: 2px;
+      border-radius: 2px;
+    }
   }
 
   p {

--- a/src/components/media-types/md/index.jsx
+++ b/src/components/media-types/md/index.jsx
@@ -33,7 +33,11 @@ export const MD = ({ displayView, artifactUri, previewUri, preview }) => {
   }, [artifactUri, previewUri, preview])
 
   return displayView ? (
-    <div className={styles.container}>
+    <div
+      className={styles.container}
+      role="article"
+      aria-label="Article content"
+    >
       <Markdown>{content}</Markdown>
     </div>
   ) : (

--- a/src/components/media-types/md/index.module.scss
+++ b/src/components/media-types/md/index.module.scss
@@ -9,6 +9,12 @@
   width: 100%;
   margin: 0 auto;
   overflow: auto;
+
+  &:focus-visible {
+    outline: 2px solid var(--text-color);
+    outline-offset: 2px;
+    border-radius: 2px;
+  }
 }
 
 .feed {

--- a/src/components/text/TextPostCard.module.scss
+++ b/src/components/text/TextPostCard.module.scss
@@ -27,12 +27,24 @@
   &:hover .title {
     color: var(--text-color);
   }
+
+  &:focus-visible {
+    outline: 2px solid var(--text-color);
+    outline-offset: 2px;
+    border-radius: 2px;
+  }
 }
 
 .cover {
   flex-shrink: 0;
   width: 160px;
   text-decoration: none;
+
+  &:focus-visible {
+    outline: 2px solid var(--text-color);
+    outline-offset: 2px;
+    border-radius: 2px;
+  }
 
   img {
     display: block;
@@ -78,6 +90,12 @@
     color: var(--text-color);
     text-decoration: underline;
   }
+
+  &:focus-visible {
+    outline: 2px solid var(--text-color);
+    outline-offset: 2px;
+    border-radius: 2px;
+  }
 }
 
 .date {
@@ -118,6 +136,12 @@
   &:hover {
     border-color: #e74c3c;
     color: #e74c3c;
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--text-color);
+    outline-offset: 2px;
+    border-radius: 2px;
   }
 }
 
@@ -194,6 +218,12 @@
     opacity: 0.5;
     cursor: not-allowed;
   }
+
+  &:focus-visible {
+    outline: 2px solid var(--text-color);
+    outline-offset: 2px;
+    border-radius: 2px;
+  }
 }
 
 .confirm_no {
@@ -212,5 +242,11 @@
   &:disabled {
     opacity: 0.5;
     cursor: not-allowed;
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--text-color);
+    outline-offset: 2px;
+    border-radius: 2px;
   }
 }

--- a/src/components/text/TokenSearchCommand.module.scss
+++ b/src/components/text/TokenSearchCommand.module.scss
@@ -22,6 +22,12 @@
   &:focus {
     border-color: var(--text-color);
   }
+
+  &:focus-visible {
+    outline: 2px solid var(--text-color);
+    outline-offset: 2px;
+    border-radius: 2px;
+  }
 }
 
 .search_hint {
@@ -68,6 +74,12 @@
 
   &:hover {
     background: var(--border-color);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--text-color);
+    outline-offset: 2px;
+    border-radius: 2px;
   }
 }
 
@@ -122,6 +134,12 @@
   &:hover {
     background: var(--border-color);
   }
+
+  &:focus-visible {
+    outline: 2px solid var(--text-color);
+    outline-offset: 2px;
+    border-radius: 2px;
+  }
 }
 
 .artist_name {
@@ -148,5 +166,11 @@
 
   &:hover {
     color: var(--text-color);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--text-color);
+    outline-offset: 2px;
+    border-radius: 2px;
   }
 }

--- a/src/pages/text/index.module.scss
+++ b/src/pages/text/index.module.scss
@@ -38,6 +38,12 @@
   a {
     color: var(--text-color);
     text-decoration: underline;
+
+    &:focus-visible {
+      outline: 2px solid var(--text-color);
+      outline-offset: 2px;
+      border-radius: 2px;
+    }
   }
 }
 
@@ -105,6 +111,12 @@
   &:focus {
     outline: none;
     border-color: var(--text-color);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--text-color);
+    outline-offset: 2px;
+    border-radius: 2px;
   }
 
   option {


### PR DESCRIPTION

* Focus Styling Added (using var(--text-color))

  - Tabs .tab (Community, Bulletin, Your Posts, New Post)
  - Markdown .content a (all links in rendered markdown)
  - MD media type .container (article content wrapper)
  - TextPostCard .post_link (post title/excerpt link)
  - TextPostCard .cover (cover image link)
  - TextPostCard .author_link (author name)
  - TextPostCard .burn_btn (burn button) 
  - TextPostCard .confirm_yes / .confirm_no (confirmation buttons)
  - TokenSearchCommand .search_input (search field)
  - TokenSearchCommand .token_item (token result button)
  - TokenSearchCommand .artist_item (artist result button)
  - TokenSearchCommand .back_btn (back navigation)
  - Text page .select (edition select dropdown)
  - Text page .empty a (empty state links)

   - Markdown display view: Added role="article" and aria-label="Article content"