### PR TITLE
feat: post-mint inline swap

### DIFF
--- a/src/components/feedback/index.jsx
+++ b/src/components/feedback/index.jsx
@@ -26,7 +26,7 @@ export const FeedbackComponent = () => {
             {footerSlot}
             <div className={styles.loader}>{progress && <Loading />}</div>
             {confirm && (
-              <div className={styles.buttons}>
+              <div className={styles.buttons} style={{ marginTop: '1rem' }}>
                 <Button shadow_box onClick={() => confirmCallback()}>
                   close
                 </Button>

--- a/src/components/feedback/index.jsx
+++ b/src/components/feedback/index.jsx
@@ -7,15 +7,15 @@ import { Markdown } from '@components/markdown'
 import { useModalStore } from '@context/modalStore'
 
 export const FeedbackComponent = () => {
-  const [visible, message, progress, confirm, confirmCallback] = useModalStore(
-    (st) => [
+  const [visible, message, progress, confirm, confirmCallback, footerSlot] =
+    useModalStore((st) => [
       st.visible,
       st.message,
       st.progress,
       st.confirm,
       st.confirmCallback,
-    ]
-  )
+      st.footerSlot,
+    ])
 
   return (
     <AnimatePresence>
@@ -23,6 +23,7 @@ export const FeedbackComponent = () => {
         <motion.div className={styles.container} {...fadeIn()}>
           <div className={styles.content}>
             <Markdown className={styles.message}>{message}</Markdown>
+            {footerSlot}
             <div className={styles.loader}>{progress && <Loading />}</div>
             {confirm && (
               <div className={styles.buttons}>

--- a/src/components/post-mint/PostMintSwapFields.jsx
+++ b/src/components/post-mint/PostMintSwapFields.jsx
@@ -19,17 +19,12 @@ export function PostMintSwapFields({
   minterAddress,
   editions,
   royaltiesPercent,
-  title,
-  previewUri,
 }) {
   const [amount, setAmount] = useState('')
   const [price, setPrice] = useState('')
-  const [currency] = useState('tez')
   const [address, swap] = useUserStore((st) => [st.address, st.swap])
   const show = useModalStore((st) => st.show)
   const [progress] = useModalStore((st) => [st.progress])
-
-  const inputStyle = { width: '75% !important' }
 
   const handleSubmit = async () => {
     if (!amount) {
@@ -40,45 +35,29 @@ export function PostMintSwapFields({
       show(`Please enter a price for the swap (current value: ${price})`)
       return
     }
-    if (currency === 'tez') {
-      await swap(
-        address,
-        royaltiesPercent,
-        parseFloat(price) * 1e6,
-        String(tokenId),
-        minterAddress,
-        parseFloat(amount)
-      )
-      useMintStore.getState().reset()
-    }
+    // Same scale as Swap tab (`nft.royalties_total / 1000`) and mint_OBJKT (`royalties * 10`).
+    await swap(
+      address,
+      Number(royaltiesPercent) * 10,
+      parseFloat(price) * 1e6,
+      String(tokenId),
+      minterAddress,
+      parseFloat(amount)
+    )
+    useMintStore.getState().reset()
   }
 
   return (
     <div style={{ marginTop: '1rem', textAlign: 'left' }}>
-      {title && (
-        <p style={{ marginBottom: '0.5rem' }}>
-          <strong>{title}</strong>
-        </p>
-      )}
-      {previewUri && (
-        <img
-          src={previewUri}
-          alt=""
-          style={{
-            maxWidth: 120,
-            maxHeight: 120,
-            objectFit: 'contain',
-            marginBottom: '0.75rem',
-          }}
-        />
-      )}
       <p>
         You own {editions} edition{editions !== 1 ? 's' : ''} of OBJKT#
-        {tokenId}. How many would you like to swap?
+        {tokenId}. How many editions would you like to swap?
       </p>
-      <div>
+      <div style={{ marginTop: '1rem' }}>
         <Input
           type="number"
+          label="Quantity"
+          name="post-mint-quantity"
           placeholder="OBJKT quantity"
           min={1}
           value={amount}
@@ -88,46 +67,33 @@ export function PostMintSwapFields({
           }}
           disabled={progress}
         />
-        <div style={{ width: '100%', display: 'flex', marginTop: 8 }}>
-          <div style={{ width: '90%' }}>
-            <Input
-              style={inputStyle}
-              type="number"
-              placeholder="Price per OBJKT"
-              value={price}
-              initial={0}
-              onChange={(v) => setPrice(v === '' ? '' : v)}
-              onBlur={() => {
-                setPrice((prev) => {
-                  const val = clampSwapPriceOnBlur(prev)
-                  maybeWarnLowSwapPrice(show, val)
-                  return val
-                })
-              }}
-              disabled={progress}
-            />
-          </div>
-          <div>
-            <select
-              value={currency}
-              disabled
-              style={{ float: 'right', display: 'inline' }}
-              aria-label="Currency"
-            >
-              <option value="tez">tez</option>
-            </select>
-          </div>
-        </div>
-        <Button
-          shadow_box
-          onClick={handleSubmit}
-          fit
-          disabled={progress}
-          style={{ marginTop: 12 }}
-        >
-          Swap
-        </Button>
       </div>
+      <Input
+        type="number"
+        label="Price"
+        name="post-mint-price"
+        placeholder="Price per OBJKT (XTZ)"
+        value={price}
+        initial={0}
+        onChange={(v) => setPrice(v === '' ? '' : v)}
+        onBlur={() => {
+          setPrice((prev) => {
+            const val = clampSwapPriceOnBlur(prev)
+            maybeWarnLowSwapPrice(show, val)
+            return val
+          })
+        }}
+        disabled={progress}
+      />
+      <Button
+        shadow_box
+        onClick={handleSubmit}
+        fit
+        disabled={progress}
+        style={{ marginTop: 12, marginBottom: 20 }}
+      >
+        Swap
+      </Button>
       <p style={{ marginTop: '1rem', fontSize: '0.9em' }}>
         {SWAP_TEIA_FEE_DISCLOSURE}
       </p>

--- a/src/components/post-mint/PostMintSwapFields.jsx
+++ b/src/components/post-mint/PostMintSwapFields.jsx
@@ -1,0 +1,136 @@
+import { useState } from 'react'
+import { Input } from '@atoms/input'
+import { Button } from '@atoms/button'
+import { useModalStore } from '@context/modalStore'
+import { useUserStore } from '@context/userStore'
+import { useMintStore } from '@context/mintStore'
+import {
+  SWAP_TEIA_FEE_DISCLOSURE,
+  maybeWarnLowSwapPrice,
+  clampSwapAmountOnBlur,
+  clampSwapPriceOnBlur,
+} from '@utils/postMintSwap'
+
+/**
+ * Inline listing form after mint (modal footerSlot).
+ */
+export function PostMintSwapFields({
+  tokenId,
+  minterAddress,
+  editions,
+  royaltiesPercent,
+  title,
+  previewUri,
+}) {
+  const [amount, setAmount] = useState('')
+  const [price, setPrice] = useState('')
+  const [currency] = useState('tez')
+  const [address, swap] = useUserStore((st) => [st.address, st.swap])
+  const show = useModalStore((st) => st.show)
+  const [progress] = useModalStore((st) => [st.progress])
+
+  const inputStyle = { width: '75% !important' }
+
+  const handleSubmit = async () => {
+    if (!amount) {
+      show(`Please enter an OBJKT quantity to swap (current value: ${amount})`)
+      return
+    }
+    if (price == null || price < 0) {
+      show(`Please enter a price for the swap (current value: ${price})`)
+      return
+    }
+    if (currency === 'tez') {
+      await swap(
+        address,
+        royaltiesPercent,
+        parseFloat(price) * 1e6,
+        String(tokenId),
+        minterAddress,
+        parseFloat(amount)
+      )
+      useMintStore.getState().reset()
+    }
+  }
+
+  return (
+    <div style={{ marginTop: '1rem', textAlign: 'left' }}>
+      {title && (
+        <p style={{ marginBottom: '0.5rem' }}>
+          <strong>{title}</strong>
+        </p>
+      )}
+      {previewUri && (
+        <img
+          src={previewUri}
+          alt=""
+          style={{
+            maxWidth: 120,
+            maxHeight: 120,
+            objectFit: 'contain',
+            marginBottom: '0.75rem',
+          }}
+        />
+      )}
+      <p>
+        You own {editions} edition{editions !== 1 ? 's' : ''} of OBJKT#
+        {tokenId}. How many would you like to swap?
+      </p>
+      <div>
+        <Input
+          type="number"
+          placeholder="OBJKT quantity"
+          min={1}
+          value={amount}
+          onChange={(v) => setAmount(String(v ?? ''))}
+          onBlur={() => {
+            setAmount((prev) => String(clampSwapAmountOnBlur(prev, editions)))
+          }}
+          disabled={progress}
+        />
+        <div style={{ width: '100%', display: 'flex', marginTop: 8 }}>
+          <div style={{ width: '90%' }}>
+            <Input
+              style={inputStyle}
+              type="number"
+              placeholder="Price per OBJKT"
+              value={price}
+              initial={0}
+              onChange={(v) => setPrice(v === '' ? '' : v)}
+              onBlur={() => {
+                setPrice((prev) => {
+                  const val = clampSwapPriceOnBlur(prev)
+                  maybeWarnLowSwapPrice(show, val)
+                  return val
+                })
+              }}
+              disabled={progress}
+            />
+          </div>
+          <div>
+            <select
+              value={currency}
+              disabled
+              style={{ float: 'right', display: 'inline' }}
+              aria-label="Currency"
+            >
+              <option value="tez">tez</option>
+            </select>
+          </div>
+        </div>
+        <Button
+          shadow_box
+          onClick={handleSubmit}
+          fit
+          disabled={progress}
+          style={{ marginTop: 12 }}
+        >
+          Swap
+        </Button>
+      </div>
+      <p style={{ marginTop: '1rem', fontSize: '0.9em' }}>
+        {SWAP_TEIA_FEE_DISCLOSURE}
+      </p>
+    </div>
+  )
+}

--- a/src/context/mintStore.ts
+++ b/src/context/mintStore.ts
@@ -1,3 +1,4 @@
+import { createElement } from 'react'
 import { create } from 'zustand'
 import {
   createJSONStorage,
@@ -25,6 +26,9 @@ import {
 import type { FileForm, Format } from '@types'
 import { prepareFilesFromZIP } from '@utils/html'
 import { prepareDirectory, prepareFile } from '@data/ipfs'
+import { fetchMintedTokenIdWithRetry } from '@data/tzktMint'
+import { PostMintSwapFields } from '@components/post-mint/PostMintSwapFields'
+import { POST_MINT_SUSTAIN_TEIA } from '@utils/postMintSwap'
 
 interface SelectField {
   label?: string
@@ -309,15 +313,78 @@ export const useMintStore = create<MintState>()(
             royalties,
           })
 
-          const success = await mint(
+          const mintStartedAtMs = Date.now()
+          const opHash = await mint(
             minterAddress,
             editions as number,
             nftCid as string,
             royalties as number
           )
-          console.debug('success', success)
-          if (success) {
+          console.debug('mint opHash', opHash)
+
+          if (!opHash) {
+            return
+          }
+
+          const proxyMint = Boolean(proxyAddress)
+          if (proxyMint) {
             reset()
+            return
+          }
+
+          const editionsNum = editions as number
+          const royaltiesNum = royalties as number
+          const previewUri =
+            typeof artifact?.reader === 'string' ? artifact.reader : undefined
+
+          step(
+            'Mint',
+            'Mint confirmed on-chain. Looking up your new OBJKT…',
+            true
+          )
+
+          const tokenId = await fetchMintedTokenIdWithRetry({
+            minterAddress,
+            mintStartedAtMs,
+            expectedEditions: editionsNum,
+          })
+
+          const tzktOp = `[View operation on tzkt.io](https://tzkt.io/${opHash})`
+
+          const onCloseExtras = () => {
+            reset()
+          }
+
+          if (tokenId) {
+            const body = `${POST_MINT_SUSTAIN_TEIA}
+
+**OBJKT #${tokenId}**
+
+${tzktOp}`
+
+            show('Mint successful', body, {
+              footerSlot: createElement(PostMintSwapFields, {
+                tokenId,
+                minterAddress,
+                editions: editionsNum,
+                royaltiesPercent: royaltiesNum,
+                title: title || undefined,
+                previewUri,
+              }),
+              onCloseExtras,
+            })
+          } else {
+            show(
+              'Mint successful',
+              `${POST_MINT_SUSTAIN_TEIA}
+
+We could not look up your OBJKT id yet (indexers can lag). Your mint is on-chain:
+
+${tzktOp}
+
+You can list this OBJKT from its page when it appears.`,
+              { onCloseExtras }
+            )
           }
         },
       }),

--- a/src/context/mintStore.ts
+++ b/src/context/mintStore.ts
@@ -334,8 +334,6 @@ export const useMintStore = create<MintState>()(
 
           const editionsNum = editions as number
           const royaltiesNum = royalties as number
-          const previewUri =
-            typeof artifact?.reader === 'string' ? artifact.reader : undefined
 
           step(
             'Mint',
@@ -350,17 +348,21 @@ export const useMintStore = create<MintState>()(
           })
 
           const tzktOp = `[View operation on tzkt.io](https://tzkt.io/${opHash})`
+          const titleLine =
+            title?.trim() !== ''
+              ? `\n\n**OBJKT #${tokenId}** - ${String(title).replace(/\n/g, ' ')}`
+              : `\n\n**OBJKT #${tokenId}**`
 
           const onCloseExtras = () => {
             reset()
           }
 
           if (tokenId) {
-            const body = `${POST_MINT_SUSTAIN_TEIA}
+            const body = `${tzktOp}
 
-**OBJKT #${tokenId}**
+----
 
-${tzktOp}`
+${POST_MINT_SUSTAIN_TEIA}${titleLine}`
 
             show('Mint successful', body, {
               footerSlot: createElement(PostMintSwapFields, {
@@ -368,19 +370,19 @@ ${tzktOp}`
                 minterAddress,
                 editions: editionsNum,
                 royaltiesPercent: royaltiesNum,
-                title: title || undefined,
-                previewUri,
               }),
               onCloseExtras,
             })
           } else {
             show(
               'Mint successful',
-              `${POST_MINT_SUSTAIN_TEIA}
+              `${tzktOp}
 
-We could not look up your OBJKT id yet (indexers can lag). Your mint is on-chain:
+----
 
-${tzktOp}
+${POST_MINT_SUSTAIN_TEIA}
+
+We could not look up your OBJKT id yet (indexers can lag). Your mint is on-chain.
 
 You can list this OBJKT from its page when it appears.`,
               { onCloseExtras }

--- a/src/context/modalStore.ts
+++ b/src/context/modalStore.ts
@@ -1,4 +1,5 @@
 import { ParametersInvalidBeaconError } from '@airgap/beacon-core'
+import type { ReactNode } from 'react'
 import { create } from 'zustand'
 import { subscribeWithSelector } from 'zustand/middleware'
 
@@ -17,7 +18,15 @@ interface ModalStore {
   progress: boolean
   confirm: boolean
   confirmCallback?: () => void
-  show: (title: string, message?: string) => void
+  /** Optional React content below markdown (e.g. post-mint inline swap). */
+  footerSlot?: ReactNode
+  /** Runs once when the user closes a modal that had footerSlot / extras. */
+  onCloseExtras?: () => void
+  show: (
+    title: string,
+    message?: string,
+    options?: { footerSlot?: ReactNode; onCloseExtras?: () => void }
+  ) => void
   showError: <T>(title: string, error: T) => void
   setCollapsed: (collapse: boolean) => void
   toggleMenu: () => void
@@ -33,16 +42,24 @@ export const useModalStore = create<ModalStore>()(
     progress: false,
     confirm: true,
     confirmCallback: () => get().close(),
-    show: (title, message) => {
+    show: (title, message, options) => {
+      const footerSlot = options?.footerSlot
+      const onCloseExtras = options?.onCloseExtras
       set({
         message: `# ${title}
 ${message || ''}`,
         progress: false,
         visible: true,
         confirm: true,
+        footerSlot,
+        onCloseExtras,
         confirmCallback: () => {
+          const extras = get().onCloseExtras
+          extras?.()
           set({
             visible: false,
+            footerSlot: undefined,
+            onCloseExtras: undefined,
           })
         },
       })
@@ -68,6 +85,8 @@ ${message || ''}`,
         progress: true,
         visible: true,
         confirm: false,
+        footerSlot: undefined,
+        onCloseExtras: undefined,
         message: `# ${title}
 ${message}`,
       })
@@ -77,6 +96,8 @@ ${message}`,
       set({
         visible: false,
         progress: false,
+        footerSlot: undefined,
+        onCloseExtras: undefined,
       })
     },
   }))

--- a/src/context/userStore.ts
+++ b/src/context/userStore.ts
@@ -70,7 +70,8 @@ interface UserState {
       amount: number
       mutez?: boolean
       storageLimit?: number
-    }
+    },
+    opOptions?: { skipSuccessModal?: boolean }
   ) => OperationReturn
   /** Wallet sync  */
   sync: (opts?: SyncOptions) => OperationReturn
@@ -130,6 +131,11 @@ const wallet = new BeaconWallet({
   name: 'teia.art',
   appUrl: 'https://teia.art',
   iconUrl: 'https://teia.art/icons/android-chrome-512x512.png',
+  // Beacon no longer accepts `network` on requestPermissions — set it here (DAppClientOptions).
+  network: {
+    type: NetworkType.MAINNET,
+    rpcUrl: String(useLocalSettings.getState().getRpcNode()),
+  },
 })
 
 Tezos.setWalletProvider(wallet)
@@ -154,10 +160,12 @@ export const useUserStore = create<UserState>()(
         proxyAddress: undefined,
         proxyName: undefined,
         subjktInfo: undefined,
-        handleOp: async (op_to_send, title, send_options) => {
+        handleOp: async (op_to_send, title, send_options, opOptions) => {
           const step = useModalStore.getState().step
           const show = useModalStore.getState().show
           const showError = useModalStore.getState().showError
+          const skipSuccessModal =
+            Boolean(opOptions?.skipSuccessModal) && title === 'Mint'
 
           // After 15sec suggest the user to cancel, it will go on
           // if they accept the tx
@@ -182,37 +190,45 @@ export const useUserStore = create<UserState>()(
             useModalStore.setState({ confirm: true })
             const confirm = await op.confirmation()
 
-            if(op_to_send.name === "collect") {
+            if (op_to_send.name === 'collect') {
               // get token information
-              const token_info = await getTokenInformationOnCollect(op_to_send.args)
-              const token_name = token_info.token.name ? token_info.token.name : `#${token_info.token_id}`
-              const artist_address = token_info.token.artist_profile?.name ? token_info.token.artist_profile.name : token_info.token.artist_address
+              const token_info = await getTokenInformationOnCollect(
+                op_to_send.args
+              )
+              const token_name = token_info.token.name
+                ? token_info.token.name
+                : `#${token_info.token_id}`
+              const artist_address = token_info.token.artist_profile?.name
+                ? token_info.token.artist_profile.name
+                : token_info.token.artist_address
 
               // get socials linked to the current user
               const user_info = await GetUserMetadata(current)
               let socials = ''
-              if(user_info.extras?.profile) {
-                for(const key in user_info.extras?.profile) {
-                  if(!['kind', 'description', 'alias'].includes(key)) { // ignore some junk
+              if (user_info.extras?.profile) {
+                for (const key in user_info.extras?.profile) {
+                  if (!['kind', 'description', 'alias'].includes(key)) {
+                    // ignore some junk
                     socials = `${key}, ${socials}`
                   }
                 }
                 socials = `Please share on ${socials.slice(0, -2)}` // drop last ,
               }
-              const collect_message = `\`\`\`\n` +
-              `I just collected "${token_name}" by the artist ${artist_address}\n` +
-              `https://teia.art/objkt/${token_info.token_id}\n` +
-              `\`\`\`\n\n` +
-              `\n\n` +
-              `${socials}` +
-              `\n\n` +
-              `\n\n` +
-              `Remember to #SwapOnTeia`
+              const collect_message =
+                `\`\`\`\n` +
+                `I just collected "${token_name}" by the artist ${artist_address}\n` +
+                `https://teia.art/objkt/${token_info.token_id}\n` +
+                `\`\`\`\n\n` +
+                `\n\n` +
+                `${socials}` +
+                `\n\n` +
+                `\n\n` +
+                `Remember to #SwapOnTeia`
               show(
                 confirm.completed ? `${title} Successful` : `${title} Error`,
                 `${collect_message}`
               )
-            } else {
+            } else if (!(skipSuccessModal && confirm.completed)) {
               show(
                 confirm.completed ? `${title} Successful` : `${title} Error`,
                 `[see on tzkt.io](https://tzkt.io/${op.opHash})`
@@ -224,10 +240,9 @@ export const useUserStore = create<UserState>()(
           }
         },
         sync: async (opts) => {
-          const network = {
-            type: NetworkType.MAINNET,
-            rpcUrl: opts?.rpcNode || useLocalSettings.getState().getRpcNode(),
-          }
+          const rpcUrl = String(
+            opts?.rpcNode || useLocalSettings.getState().getRpcNode()
+          )
 
           // Set the client theme
           // const theme = JSON.parse(localStorage.getItem('settings:theme'))
@@ -238,13 +253,24 @@ export const useUserStore = create<UserState>()(
           // We check the storage and only do a permission request if we don't have an active account yet
           // This piece of code should be called on startup to "load" the current address from the user
           // If the activeAccount is present, no "permission request" is required again, unless the user "disconnects" first.
+          let activeAccount = await wallet.client.getActiveAccount()
+          if (
+            activeAccount === undefined ||
+            activeAccount?.network?.rpcUrl !== rpcUrl
+          ) {
+            // Beacon: network is configured on DAppClient / BeaconWallet constructor, not here.
+            await wallet.requestPermissions()
+            activeAccount = await wallet.client.getActiveAccount()
+          }
+          const current = await wallet.getPKH()
+          if (current) {
+            const info = await getUser(current)
+            set({
+              address: current,
+              userInfo: info,
+            })
+          }
 
-          await wallet.client.requestPermissions()
-          const info = await getUser(current)
-          set({
-            address: current,
-            userInfo: await getUser(current),
-          })
           return current
         },
         unsync: async () => {
@@ -630,10 +656,15 @@ export const useUserStore = create<UserState>()(
             royalties: royalties * 10}
           )
 
-          return await handleOp(mint_batch, 'Mint', {
-            amount: 0,
-            storageLimit: 310,
-          })
+          return await handleOp(
+            mint_batch,
+            'Mint',
+            {
+              amount: 0,
+              storageLimit: 310,
+            },
+            { skipSuccessModal: !proxyAddress }
+          )
         },
       }),
       {

--- a/src/data/tzktMint.ts
+++ b/src/data/tzktMint.ts
@@ -1,0 +1,108 @@
+import axios from 'axios'
+import { HEN_CONTRACT_FA2, MARKETPLACE_CONTRACT_V1 } from '@constants'
+
+export type FetchMintedTokenIdParams = {
+  minterAddress: string
+  /** Epoch ms before `mint()` was invoked (buffer for clock skew). */
+  mintStartedAtMs: number
+  /** Editions minted (FA2 transfer amount should match). */
+  expectedEditions: number
+}
+
+type TzktTokenTransfer = {
+  timestamp: string
+  amount: string
+  from?: { address?: string }
+  to?: { address?: string }
+  token?: { tokenId?: string; contract?: { address?: string } }
+}
+
+const baseUrl = () => import.meta.env.VITE_TZKT_API.replace(/\/$/, '')
+
+function parseTsMs(iso: string): number {
+  const t = Date.parse(iso)
+  return Number.isNaN(t) ? 0 : t
+}
+
+/**
+ * Poll TzKT token transfers for a fresh FA2 mint to `minterAddress` on H=N contract.
+ * Mints typically appear as a transfer with no `from` (mint credit) to the minter.
+ */
+export async function fetchMintedTokenIdWithRetry(
+  params: FetchMintedTokenIdParams,
+  options?: {
+    maxAttempts?: number
+    initialDelayMs?: number
+    maxDelayMs?: number
+  }
+): Promise<string | null> {
+  const maxAttempts = options?.maxAttempts ?? 25
+  const initialDelayMs = options?.initialDelayMs ?? 400
+  const maxDelayMs = options?.maxDelayMs ?? 4000
+
+  const { minterAddress, mintStartedAtMs, expectedEditions } = params
+  const expectedAmount = String(expectedEditions)
+
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    if (attempt > 0) {
+      const delay = Math.min(
+        maxDelayMs,
+        Math.floor(initialDelayMs * Math.pow(1.35, attempt - 1))
+      )
+      await new Promise((r) => setTimeout(r, delay))
+    }
+
+    try {
+      const { data } = await axios.get<TzktTokenTransfer[]>(
+        `${baseUrl()}/v1/tokens/transfers`,
+        {
+          params: {
+            'token.contract': HEN_CONTRACT_FA2,
+            'to.eq': minterAddress,
+            'sort.desc': 'id',
+            limit: 40,
+          },
+          timeout: 15000,
+        }
+      )
+
+      if (!Array.isArray(data)) {
+        continue
+      }
+
+      const cutoffMs = mintStartedAtMs - 15_000
+
+      for (const row of data) {
+        if (row.token?.contract?.address !== HEN_CONTRACT_FA2) {
+          continue
+        }
+        if (row.to?.address?.toLowerCase() !== minterAddress.toLowerCase()) {
+          continue
+        }
+        const fromAddr = row.from?.address
+        // Mint credit: no sender, or transfer from HEN v1 minter contract.
+        if (
+          fromAddr &&
+          fromAddr !== MARKETPLACE_CONTRACT_V1 &&
+          fromAddr !== HEN_CONTRACT_FA2
+        ) {
+          continue
+        }
+        if (row.amount !== expectedAmount) {
+          continue
+        }
+        if (parseTsMs(row.timestamp) < cutoffMs) {
+          continue
+        }
+        const id = row.token?.tokenId
+        if (id != null && id !== '') {
+          return String(id)
+        }
+      }
+    } catch (e) {
+      console.warn('TzKT mint token lookup failed', e)
+    }
+  }
+
+  return null
+}

--- a/src/pages/objkt-display/tabs/Swap.jsx
+++ b/src/pages/objkt-display/tabs/Swap.jsx
@@ -8,6 +8,12 @@ import styles from '@style'
 import { useModalStore } from '@context/modalStore'
 import { useUserStore } from '@context/userStore'
 import { useObjktDisplayContext } from '..'
+import {
+  SWAP_TEIA_FEE_DISCLOSURE,
+  maybeWarnLowSwapPrice,
+  clampSwapAmountOnBlur,
+  clampSwapPriceOnBlur,
+} from '@utils/postMintSwap'
 
 /**
  * The Swap Tab
@@ -39,11 +45,7 @@ export const Swap = () => {
 
   const checkPrice = (value) => {
     console.debug(value)
-    if (value <= 0.1) {
-      show(
-        `Price is really low (${value}ꜩ), for giveaways checkout hicetdono (dono.xtz.tools)`
-      )
-    }
+    maybeWarnLowSwapPrice(show, value)
   }
 
   const proxyAdminAddress = nft.artist_profile?.is_split
@@ -120,9 +122,9 @@ export const Swap = () => {
                 /* max={total_amount - sales} */
                 onChange={setAmount}
                 onBlur={(e) => {
-                  if (parseInt(e.target.value) > totalOwned) {
-                    setAmount(totalOwned)
-                  }
+                  setAmount(
+                    String(clampSwapAmountOnBlur(e.target.value, totalOwned))
+                  )
                 }}
                 disabled={progress}
               />
@@ -137,12 +139,8 @@ export const Swap = () => {
                     initial={0}
                     onChange={setPrice}
                     onBlur={(e) => {
-                      const val = parseFloat(e.target.value)
-                      if (val > 1e6) {
-                        setPrice(1e6)
-                      } else if (val < 0) {
-                        setPrice(0)
-                      }
+                      const val = clampSwapPriceOnBlur(e.target.value)
+                      setPrice(val)
                       checkPrice(val)
                     }}
                     disabled={progress}
@@ -157,11 +155,7 @@ export const Swap = () => {
 
           <Container>
             <div className={styles.container}>
-              <p>
-                The Teia marketplace fee is set to 2.5%. Fees get directed to
-                the Teia DAO treasury multisig
-                (KT1J9FYz29RBQi1oGLw8uXyACrzXzV1dHuvb)
-              </p>
+              <p>{SWAP_TEIA_FEE_DISCLOSURE}</p>
             </div>
           </Container>
         </div>

--- a/src/utils/postMintSwap.js
+++ b/src/utils/postMintSwap.js
@@ -1,0 +1,54 @@
+/** Shared copy and validation for OBJKT listing (Swap tab + post-mint inline). */
+
+export const SWAP_TEIA_FEE_DISCLOSURE =
+  'The Teia marketplace fee is set to 2.5%. Fees get directed to ' +
+  'the Teia DAO treasury multisig (KT1J9FYz29RBQi1oGLw8uXyACrzXzV1dHuvb)'
+
+export const POST_MINT_SUSTAIN_TEIA =
+  'Please help sustain Teia, swap your new OBJKT on Teia:'
+
+const PRICE_MAX = 1e6
+const LOW_PRICE_WARN_THRESHOLD = 0.1
+
+/**
+ * @param {(title: string, message?: string) => void} showModal
+ * @param {number} value
+ */
+export function maybeWarnLowSwapPrice(showModal, value) {
+  if (value <= LOW_PRICE_WARN_THRESHOLD) {
+    showModal(
+      `Price is really low (${value}ꜩ), for giveaways checkout hicetdono (dono.xtz.tools)`
+    )
+  }
+}
+
+/**
+ * @param {unknown} raw
+ * @param {number} totalOwned
+ * @returns {number}
+ */
+export function clampSwapAmountOnBlur(raw, totalOwned) {
+  const n = parseInt(String(raw), 10)
+  if (Number.isNaN(n) || n < 1) {
+    return 1
+  }
+  return Math.min(n, totalOwned)
+}
+
+/**
+ * @param {unknown} raw
+ * @returns {number}
+ */
+export function clampSwapPriceOnBlur(raw) {
+  let val = parseFloat(String(raw))
+  if (Number.isNaN(val)) {
+    return 0
+  }
+  if (val > PRICE_MAX) {
+    return PRICE_MAX
+  }
+  if (val < 0) {
+    return 0
+  }
+  return val
+}


### PR DESCRIPTION
This adds an option to swap directly from the Mint confirmation modal, encouraging swaps on Teia, and allowing these swaps to happen even before indexers catch up with the new OBJKT.