### PR TITLE
Add verified Bluesky links to profiles

### DIFF
--- a/.env
+++ b/.env
@@ -13,6 +13,11 @@ VITE_TEIA_DONATION_API='https://teia-donation-express-app-production.up.railway.
 
 VITE_TZPROFILES_GRAPHQL_API='https://indexer.tzprofiles.com/v1/graphql'
 
+# tzbsky: wallet address -> Bluesky (atproto) identity
+VITE_TZBSKY_API='https://tzbsky.com'
+VITE_PLC_DIRECTORY='https://plc.directory'
+VITE_BSKY_PUBLIC_API='https://public.api.bsky.app'
+
 VITE_IMGPROXY='https://imgproxy.teia.rocks'
 
 VITE_IPFS_UPLOAD_PROXY='https://ipfsproxy.teia.rocks'

--- a/src/components/header/feed_toolbar/FeedToolbar.jsx
+++ b/src/components/header/feed_toolbar/FeedToolbar.jsx
@@ -1,4 +1,5 @@
 // ! NOTE - Keep the comments.
+import { Fragment } from 'react'
 import { motion } from 'framer-motion'
 import styles from '@style'
 import { DropDown, DropdownButton } from '@atoms/dropdown'
@@ -88,12 +89,12 @@ export const FeedToolbar = ({ feeds_menu = false }) => {
                 {[...locationMap.keys()].map((k) => {
                   if (k.startsWith('-')) {
                     return (
-                      <>
-                        <Line className={styles.separator} key={k} />
+                      <Fragment key={k}>
+                        <Line className={styles.separator} />
                         <span className={styles.subtitle}>
                           {locationMap.get(k)}
                         </span>
-                      </>
+                      </Fragment>
                     )
                   }
                   if (locationNeedSync.includes(k)) {

--- a/src/pages/profile/profile.jsx
+++ b/src/pages/profile/profile.jsx
@@ -8,6 +8,7 @@ import { useDisplayStore } from '.'
 import ParticipantList from '@components/collab/manage/ParticipantList'
 import { useCallback, useEffect, useState } from 'react'
 import axios from 'axios'
+import { resolveVerifiedBluesky } from '@utils/bsky'
 
 async function reverseRecord(address) {
   const result = await axios.post(
@@ -36,6 +37,7 @@ export default function Profile({ user }) {
 
   const coreParticipants = useDisplayStore((st) => st.coreParticipants)
   const [reverseDomain, setReverseDomain] = useState('')
+  const [bluesky, setBluesky] = useState(null)
 
   const loadReverseDomain = useCallback(() => {
     reverseRecord(user.address).then((domain) => {
@@ -43,9 +45,22 @@ export default function Profile({ user }) {
     })
   }, [user.address])
 
+  const loadBluesky = useCallback(() => {
+    let active = true
+    setBluesky(null)
+    resolveVerifiedBluesky(user.address).then((result) => {
+      if (active) setBluesky(result)
+    })
+    return () => {
+      active = false
+    }
+  }, [user.address])
+
   useEffect(() => {
     loadReverseDomain()
   }, [loadReverseDomain])
+
+  useEffect(() => loadBluesky(), [loadBluesky])
 
   return (
     <div className={styles.container}>
@@ -80,6 +95,28 @@ export default function Profile({ user }) {
           )}
 
           <div className={styles.socials}>
+            {bluesky?.handle && (
+              <Button
+                alt={`User on Bluesky (@${bluesky.handle}), verified via on-chain signature`}
+                href={`https://bsky.app/profile/${bluesky.did}`}
+              >
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="16"
+                  height="16"
+                  viewBox="0 0 568 501"
+                  fill="currentColor"
+                  style={{
+                    fill: 'var(--text-color)',
+                    stroke: 'transparent',
+                    marginRight: '10px',
+                  }}
+                >
+                  <path d="M123.121 33.664C188.241 82.553 258.281 181.68 284 234.873c25.719-53.193 95.759-152.32 160.879-201.21C491.866-1.611 568-28.906 568 57.947c0 17.346-9.945 145.713-15.778 166.555-20.275 72.453-94.155 90.933-159.875 79.748C507.222 323.8 536.444 388.56 473.333 453.32c-119.86 122.992-172.272-30.859-185.702-70.281-2.462-7.227-3.614-10.608-3.631-7.733-.017-2.875-1.169.506-3.631 7.733-13.43 39.422-65.842 193.273-185.702 70.281-63.111-64.76-33.889-129.52 80.986-149.071-65.72 11.185-139.6-7.295-159.875-79.748C9.945 203.66 0 75.293 0 57.947 0-28.906 76.134-1.611 123.121 33.664Z" />
+                </svg>
+              </Button>
+            )}
+
             {user.extras?.profile?.twitter && (
               <Button
                 alt={`User profile on Twitter (@${user.extras?.profile?.twitter})`}

--- a/src/utils/bsky.js
+++ b/src/utils/bsky.js
@@ -1,0 +1,160 @@
+import axios from 'axios'
+import { verifySignature, getPkhfromPk } from '@taquito/utils'
+
+// Resolve a Tezos wallet address to a verified Bluesky (atproto) identity.
+//
+// tzbsky's index is used only to *discover* a candidate DID; trust comes
+// from the signed record in the DID's own atproto repo, which we fetch and
+// verify ourselves. A wrong/malicious index can only point at a different
+// DID whose repo will not contain a wallet-signed binding for this address,
+// so verification fails closed.
+
+const TZBSKY_API = import.meta.env.VITE_TZBSKY_API || 'https://tzbsky.com'
+const PLC_DIRECTORY =
+  import.meta.env.VITE_PLC_DIRECTORY || 'https://plc.directory'
+const BSKY_PUBLIC_API =
+  import.meta.env.VITE_BSKY_PUBLIC_API || 'https://public.api.bsky.app'
+
+const COLLECTION = 'com.tzbsky.cryptoAddress'
+
+const toHex = (bytes) =>
+  Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('')
+
+// Micheline PACK of a string value: 0x05 0x01 <4-byte BE length> <utf8 bytes>.
+// @taquito's verifySignature blake2b-256 hashes this and verifies the curve
+// signature, so we only need to reproduce the packed payload as hex.
+const packMichelineString = (message) => {
+  const utf8 = new TextEncoder().encode(message)
+  const len = utf8.length
+  const be32 = new Uint8Array([
+    (len >>> 24) & 0xff,
+    (len >>> 16) & 0xff,
+    (len >>> 8) & 0xff,
+    len & 0xff,
+  ])
+  // 0x05 = PACK magic byte, 0x01 = Micheline string tag
+  return '0501' + toHex(be32) + toHex(utf8)
+}
+
+const parseMessageFields = (message) => {
+  const fields = {}
+  for (const line of message.split('\n')) {
+    const eq = line.indexOf('=')
+    if (eq > 0) fields[line.slice(0, eq).trim()] = line.slice(eq + 1).trim()
+  }
+  return fields
+}
+
+// address -> candidate DID (untrusted discovery hint).
+const lookupDid = async (address) => {
+  const { data } = await axios.get(
+    `${TZBSKY_API}/api/lookup/address/tezos/${address}`
+  )
+  return data?.did || null
+}
+
+// DID -> PDS service endpoint (where the repo lives).
+const resolvePds = async (did) => {
+  let doc
+  if (did.startsWith('did:plc:')) {
+    doc = (await axios.get(`${PLC_DIRECTORY}/${did}`)).data
+  } else if (did.startsWith('did:web:')) {
+    const rest = did.slice('did:web:'.length).split(':')
+    const domain = decodeURIComponent(rest[0])
+    const path =
+      rest.length > 1
+        ? `/${rest.slice(1).map(decodeURIComponent).join('/')}/did.json`
+        : '/.well-known/did.json'
+    doc = (await axios.get(`https://${domain}${path}`)).data
+  } else {
+    return null
+  }
+  const service = (doc?.service || []).find(
+    (s) =>
+      s.type === 'AtprotoPersonalDataServer' ||
+      (typeof s.id === 'string' && s.id.endsWith('#atproto_pds'))
+  )
+  return service?.serviceEndpoint || null
+}
+
+const fetchRecord = async (pds, did) => {
+  const { data } = await axios.get(`${pds}/xrpc/com.atproto.repo.getRecord`, {
+    params: { repo: did, collection: COLLECTION, rkey: 'self' },
+  })
+  return data?.value || null
+}
+
+// DID -> current handle. Display-only: the handle is mutable and is not part
+// of the proof, so it is resolved fresh and never treated as the identity.
+const resolveHandle = async (did) => {
+  const { data } = await axios.get(
+    `${BSKY_PUBLIC_API}/xrpc/app.bsky.actor.getProfile`,
+    { params: { actor: did } }
+  )
+  return data?.handle || null
+}
+
+// Both checks are mandatory:
+//  1. binding   - the signed message names *this* repo's DID and *this*
+//                 address, so a signature lifted from elsewhere cannot be
+//                 replayed into another repo.
+//  2. signature - the wallet key signed that exact message, and that key
+//                 derives the address being looked up.
+const verifyEntry = (entry, did, address) => {
+  if (!entry || entry.chain !== 'tezos') return false
+  if (entry.address !== address) return false
+
+  const proof = entry.proof
+  if (!proof || proof.scheme !== 'tezos-micheline') return false
+  if (!proof.message || !proof.signature || !entry.publicKey) return false
+
+  const fields = parseMessageFields(proof.message)
+  if (fields.did !== did) return false
+  if (fields.address !== address) return false
+  if (fields.chain !== 'tezos') return false
+
+  let derived
+  try {
+    derived = getPkhfromPk(entry.publicKey)
+  } catch {
+    return false
+  }
+  if (derived !== address) return false
+
+  try {
+    return verifySignature(
+      packMichelineString(proof.message),
+      entry.publicKey,
+      proof.signature
+    )
+  } catch {
+    return false
+  }
+}
+
+// Returns { did, handle } only if the address ↔ DID link verifies, else null.
+// Never throws; any network or verification failure yields null so the UI
+// simply omits the link. Do not cache the result — there is no cryptographic
+// revocation, so the current record is authoritative on each load.
+export const resolveVerifiedBluesky = async (address) => {
+  try {
+    if (!address) return null
+
+    const did = await lookupDid(address)
+    if (!did) return null
+
+    const pds = await resolvePds(did)
+    if (!pds) return null
+
+    const record = await fetchRecord(pds, did)
+    const entry = (record?.addresses || []).find((e) => e.chain === 'tezos')
+    if (!verifyEntry(entry, did, address)) return null
+
+    const handle = await resolveHandle(did)
+    if (!handle) return null
+
+    return { did, handle }
+  } catch {
+    return null
+  }
+}


### PR DESCRIPTION
## Add verified Bluesky links to profiles

> 🚧 **WIP — keeping this as a draft for now.** Kindly requesting a review of the feature on this branch; I'm open to suggestions on any of it (UX, the verification approach, where the code lives, etc.).

Tezos Commons is about to launch [tzbsky.com](https://tzbsky.com) as part of an effort to bring the Tezos community onto ATProto / Bluesky. The service lets people link their Bluesky and Tezos/Etherlink accounts, which opens up things like custom badges, Tezos-only feeds, and other community goodies on the Bluesky side.

It also lets a user **publicly** link a Tezos address to their Bluesky account (their ATProto DID) by publishing a signed record to their own Personal Data Server (PDS). tzbsky.com additionally exposes a reverse-lookup API over those public records.

This PR adds a small Bluesky icon to any profile whose owner has published such a link — so visitors can jump straight to their Bluesky account. **The link is verified client-side before we show it**: we don't just trust the lookup API, we check the on-PDS signature ourselves.

A working example, when running this branch locally: http://localhost:3000/tz/tz1cxfPsZ2h74snLzh6MkjhmezvekW9vog5B

### Quick ATProto primer: DID and PDS

Bluesky is built on ATProto, where two concepts matter here:

- **DID** (Decentralized Identifier) — the *stable* identity of an account, e.g. `did:plc:abc123…`. It never changes, even if the user renames their handle or moves servers. The human-readable handle (`@alice.bsky.social`) is just a mutable pointer *to* a DID, which is why we always link and verify against the DID and treat the handle as a display label only. A DID resolves to a small JSON document that says, among other things, which server currently hosts the account's data.
- **PDS** (Personal Data Server) — the server that actually stores a user's repository: their posts, profile, and any other records, including the Tezos↔Bluesky link record. Crucially the PDS is *the user's own* (self-hostable, or Bluesky-hosted), and records there are signed by the account's repo key — so a record fetched from someone's PDS is something *they* put there, not something tzbsky or anyone else asserts on their behalf, tzbsky merely has a nice interface for doing this.

So the chain is: address → DID (who) → PDS (where their data lives) → the signed link record (the proof).

### How it works

For each profile we take the wallet address and:

1. **Discover a candidate DID** via the tzbsky reverse-lookup API. This is treated as an *untrusted hint* — a bad answer here can't fool us, it just makes the next steps fail.
2. **Resolve the DID to its PDS** (`plc.directory` for `did:plc`, the domain's `did.json` for `did:web`) and **fetch the signed record** (`com.tzbsky.cryptoAddress`) straight from the user's own PDS.
3. **Verify it ourselves**, two independent checks, both required:
   - **Binding** — the signed message must name *this* DID, *this* address, and `chain=tezos`. This is what stops a valid signature being lifted from somewhere else and replayed into another repo.
   - **Signature** — verified as described below.
4. **Resolve the current handle** from the DID, purely for display — the handle is mutable and never part of the proof, so the link points at the stable DID and the handle is just the label.

If anything fails — no record, bad signature, network hiccup — we simply don't show the icon. Nothing is cached: there's no cryptographic revocation, so the record is re-fetched and re-verified on every profile view. The badge links to `bsky.app/profile/<did>`.

### The signature

The record stores the wallet signature over a plain-text attestation message (the lines naming the DID, address, chain, etc.). To verify it we have to reconstruct the *exact bytes the wallet signed*, which is a Tezos off-chain signed message — i.e. a **Michelson value packed in the PACK format**:

```
0x05 0x01 <4-byte big-endian length> <utf-8 message bytes>
```

`0x05` is the PACK magic byte, `0x01` is the Micheline `string` tag, then the length-prefixed UTF-8 message. We build that byte string, then hand it to `@taquito/utils` `verifySignature`, which Blake2b-256 hashes it and checks the signature against the public key on the appropriate curve (Ed25519 / secp256k1 / P-256, picked from the key prefix). Separately we derive the address from that same public key (`getPkhfromPk`) and require it to equal the address we're looking up — so the key that signed is provably the key that owns the wallet, not just *some* valid key over the message.

### On tzbsky being optional

Worth being explicit: **the proof does not depend on tzbsky.com at all.** The trust comes entirely from the signed record living in the user's own PDS plus the signature check above. If you maintained your own index of these public ATProto records (they're public by design), you could do this lookup with zero involvement from tzbsky — resolve the DID, fetch the record, verify. The reverse-lookup API is purely a convenience so we don't have to crawl and index every PDS ourselves; it makes the address→DID step easy, but it's not part of the security model and a wrong/missing answer there only causes the check to fail closed, never to falsely succeed.
