### PR TITLE
Update Copyright Token Card tzkt Link

### DIFF
--- a/src/components/copyright/marketplace/CopyrightListItem.tsx
+++ b/src/components/copyright/marketplace/CopyrightListItem.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 import type { CopyrightEntry } from '../shared/CopyrightTypes'
 import ClausesPreview from '../shared/ClausesPreview'
-import TokenCard from '../shared/TokenCard'
+import RegisteredWorks from '../shared/RegisteredWorks'
 import AgreementViewer from '../shared/AgreementViewer'
 import styles from './index.module.scss'
 import sharedStyles from '../shared/index.module.scss'
@@ -106,15 +106,7 @@ export default function CopyrightListItem({ entry, aliases }: CopyrightListItemP
           {nfts.length > 0 && (
             <>
               <h4 className={sharedStyles.sectionTitle}>Registered Works</h4>
-              <div className={sharedStyles.tokensGrid}>
-                {nfts.map((nft) => (
-                  <TokenCard
-                    key={`${nft.contract}:${nft.token_id}`}
-                    contract={nft.contract}
-                    tokenId={nft.token_id}
-                  />
-                ))}
-              </div>
+              <RegisteredWorks nfts={nfts} />
             </>
           )}
 

--- a/src/components/copyright/profile/CopyrightDisplay.tsx
+++ b/src/components/copyright/profile/CopyrightDisplay.tsx
@@ -1,11 +1,11 @@
 import { useState, useEffect } from 'react'
 import { useOutletContext } from 'react-router'
-import { fetchUserCopyrights, fetchCreatorAliases, fetchTokenMetadataForCopyrightSearch } from '@data/swr'
+import { fetchUserCopyrights, fetchCreatorAliases, fetchTokensMetadataBatch } from '@data/swr'
 import { HashToURL } from '@utils'
 import { Loading } from '@atoms/loading'
 import type { CopyrightEntry } from '../shared/CopyrightTypes'
 import ClausesPreview from '../shared/ClausesPreview'
-import TokenCard from '../shared/TokenCard'
+import RegisteredWorks from '../shared/RegisteredWorks'
 import AgreementViewer from '../shared/AgreementViewer'
 import styles from './index.module.scss'
 import sharedStyles from '../shared/index.module.scss'
@@ -18,7 +18,6 @@ export default function CopyrightDisplay() {
   const [expandedId, setExpandedId] = useState<number | null>(null)
   const [showFullText, setShowFullText] = useState<Record<number, boolean>>({})
   const [thumbnails, setThumbnails] = useState<Record<string, string>>({})
-  const [tokenMeta, setTokenMeta] = useState<Record<string, any>>({})
 
   useEffect(() => {
     if (!address) return
@@ -31,31 +30,26 @@ export default function CopyrightDisplay() {
       const addresses = [...new Set(data.map((e) => e.key.address))]
       fetchCreatorAliases(addresses).then(setAliases)
 
-      // Fetch thumbnails for all NFTs across all entries
-      const allNfts = data.flatMap((e) =>
-        e.value.related_tezos_nfts.map((nft) => ({ ...nft, entryId: e.id }))
-      )
-      const thumbResults = await Promise.allSettled(
-        allNfts.map(async (nft) => {
-          const meta = await fetchTokenMetadataForCopyrightSearch(nft.contract, nft.token_id)
-          const md = meta?.metadata || {}
-          const src =
-            (md.thumbnailUri && HashToURL(md.thumbnailUri, 'IPFS')) ||
-            (md.displayUri && HashToURL(md.displayUri, 'IPFS')) ||
-            (md.artifactUri && HashToURL(md.artifactUri, 'IPFS'))
-          return { key: `${nft.contract}:${nft.token_id}`, src, md }
-        })
+      // Fetch a single cover thumbnail per copyright (its first registered
+      // work), batched. The remaining works load lazily when a copyright is
+      // expanded (see RegisteredWorks).
+      const coverNfts = data
+        .map((e) => e.value.related_tezos_nfts[0])
+        .filter(Boolean)
+      const coverMeta = await fetchTokensMetadataBatch(
+        coverNfts.map((nft) => ({ contract: nft.contract, tokenId: nft.token_id }))
       )
       const thumbMap: Record<string, string> = {}
-      const metaMap: Record<string, any> = {}
-      thumbResults.forEach((r) => {
-        if (r.status === 'fulfilled') {
-          if (r.value.src) thumbMap[r.value.key] = r.value.src
-          metaMap[r.value.key] = r.value.md
-        }
+      coverNfts.forEach((nft) => {
+        const md = coverMeta.get(`${nft.contract}:${nft.token_id}`)
+        if (!md) return
+        const src =
+          (md.thumbnailUri && HashToURL(md.thumbnailUri, 'IPFS')) ||
+          (md.displayUri && HashToURL(md.displayUri, 'IPFS')) ||
+          (md.artifactUri && HashToURL(md.artifactUri, 'IPFS'))
+        if (src) thumbMap[`${nft.contract}:${nft.token_id}`] = src
       })
       setThumbnails(thumbMap)
-      setTokenMeta(metaMap)
     })
   }, [address])
 
@@ -114,15 +108,15 @@ export default function CopyrightDisplay() {
 
                 {works > 0 && (
                   <div className={styles.thumbStrip}>
-                    {entry.value.related_tezos_nfts.map((nft) => {
-                      const key = `${nft.contract}:${nft.token_id}`
-                      const src = thumbnails[key]
+                    {(() => {
+                      const cover = entry.value.related_tezos_nfts[0]
+                      const src = thumbnails[`${cover.contract}:${cover.token_id}`]
                       return src ? (
-                        <img key={key} src={src} alt="" className={styles.thumbImg} />
+                        <img src={src} alt="" className={styles.thumbImg} />
                       ) : (
-                        <div key={key} className={styles.thumbPlaceholder} />
+                        <div className={styles.thumbPlaceholder} />
                       )
-                    })}
+                    })()}
                   </div>
                 )}
 
@@ -166,16 +160,7 @@ export default function CopyrightDisplay() {
                   {entry.value.related_tezos_nfts.length > 0 && (
                     <>
                       <h4 className={sharedStyles.sectionTitle}>Registered Works</h4>
-                      <div className={sharedStyles.tokensGrid}>
-                        {entry.value.related_tezos_nfts.map((nft) => (
-                          <TokenCard
-                            key={`${nft.contract}:${nft.token_id}`}
-                            contract={nft.contract}
-                            tokenId={nft.token_id}
-                            metadata={tokenMeta[`${nft.contract}:${nft.token_id}`]}
-                          />
-                        ))}
-                      </div>
+                      <RegisteredWorks nfts={entry.value.related_tezos_nfts} />
                     </>
                   )}
 

--- a/src/components/copyright/shared/RegisteredWorks.tsx
+++ b/src/components/copyright/shared/RegisteredWorks.tsx
@@ -1,0 +1,79 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import Button from '@atoms/button/Button'
+import { Loading } from '@atoms/loading'
+import { fetchTokensMetadataBatch } from '@data/swr'
+import TokenCard from './TokenCard'
+import type { NFTMetadata } from './CopyrightTypes'
+import styles from './index.module.scss'
+
+const WORKS_PER_PAGE = 12
+
+interface RegisteredWorksProps {
+  nfts: Array<{ contract: string; token_id: string }>
+}
+
+/**
+ * Renders a copyright's registered works, batching metadata requests and
+ * paginating with a "Load More" button. Mounted only inside an expanded
+ * copyright, so fetching happens on open (not on page load), and a large
+ * copyright loads its works a page at a time.
+ */
+export default function RegisteredWorks({ nfts }: RegisteredWorksProps) {
+  const [visibleCount, setVisibleCount] = useState(0)
+  const [meta, setMeta] = useState<Map<string, NFTMetadata>>(new Map())
+  const [loading, setLoading] = useState(false)
+
+  // Fetch metadata for the next page, then reveal it (fetch-before-reveal so a
+  // card's metadata is present by the time it renders).
+  const loadNextPage = useCallback(
+    async (from: number) => {
+      const slice = nfts.slice(from, from + WORKS_PER_PAGE)
+      if (slice.length === 0) return
+      setLoading(true)
+      const batch = await fetchTokensMetadataBatch(
+        slice.map((nft) => ({ contract: nft.contract, tokenId: nft.token_id }))
+      )
+      setMeta((prev) => new Map([...prev, ...batch]))
+      setVisibleCount(from + slice.length)
+      setLoading(false)
+    },
+    [nfts]
+  )
+
+  // Load the first page once, when the works become visible.
+  const initialized = useRef(false)
+  useEffect(() => {
+    if (initialized.current || nfts.length === 0) return
+    initialized.current = true
+    loadNextPage(0)
+  }, [nfts, loadNextPage])
+
+  const hasMore = visibleCount < nfts.length
+
+  return (
+    <>
+      <div className={styles.tokensGrid}>
+        {nfts.slice(0, visibleCount).map((nft) => (
+          <TokenCard
+            key={`${nft.contract}:${nft.token_id}`}
+            contract={nft.contract}
+            tokenId={nft.token_id}
+            metadata={meta.get(`${nft.contract}:${nft.token_id}`)}
+            managed
+          />
+        ))}
+      </div>
+      {(hasMore || loading) && (
+        <div className={styles.worksLoadMore}>
+          {loading ? (
+            <Loading message="Loading works..." />
+          ) : (
+            <Button onClick={() => loadNextPage(visibleCount)} shadow_box>
+              Load More ({nfts.length - visibleCount})
+            </Button>
+          )}
+        </div>
+      )}
+    </>
+  )
+}

--- a/src/components/copyright/shared/TokenCard.tsx
+++ b/src/components/copyright/shared/TokenCard.tsx
@@ -9,17 +9,24 @@ interface TokenCardProps {
   contract: string
   tokenId: string
   metadata?: NFTMetadata
+  managed?: boolean
 }
 
-export default function TokenCard({ contract, tokenId, metadata }: TokenCardProps) {
+export default function TokenCard({ contract, tokenId, metadata, managed }: TokenCardProps) {
   const [meta, setMeta] = useState<NFTMetadata>(metadata || {})
 
+  // Sync local state when the parent supplies/updates metadata.
   useEffect(() => {
-    if (metadata) return
+    if (metadata) setMeta(metadata)
+  }, [metadata])
+
+  useEffect(() => {
+    // Parent-managed cards wait for the batched result; they never self-fetch.
+    if (managed || metadata) return
     fetchTokenMetadataForCopyrightSearch(contract, tokenId)
       .then((data) => setMeta(data?.metadata || {}))
       .catch(() => setMeta({}))
-  }, [contract, tokenId, metadata])
+  }, [contract, tokenId, metadata, managed])
 
   const imageSrc =
     (meta.thumbnailUri && HashToURL(meta.thumbnailUri, 'IPFS')) ||

--- a/src/components/copyright/shared/TokenCard.tsx
+++ b/src/components/copyright/shared/TokenCard.tsx
@@ -27,7 +27,9 @@ export default function TokenCard({ contract, tokenId, metadata }: TokenCardProp
     (meta.artifactUri && HashToURL(meta.artifactUri, 'IPFS'))
 
   const isHen = contract === HEN_CONTRACT_FA2
-  const link = isHen ? `/objkt/${tokenId}` : `${import.meta.env.VITE_TZKT_API?.replace('/v1', '')}/${contract}/tokens/${tokenId}`
+  const link = isHen
+    ? `/objkt/${tokenId}`
+    : `https://tzkt.io/${contract}/tokens/${tokenId}/metadata`
 
   return (
     <div className={styles.tokenCard}>

--- a/src/components/copyright/shared/index.module.scss
+++ b/src/components/copyright/shared/index.module.scss
@@ -244,6 +244,12 @@
   }
 }
 
+.worksLoadMore {
+  display: flex;
+  justify-content: center;
+  margin-top: 0.75rem;
+}
+
 .emptyState {
   text-align: center;
   padding: 3rem 1rem;

--- a/src/data/swr.js
+++ b/src/data/swr.js
@@ -338,6 +338,96 @@ export const fetchTokenMetadataForCopyrightSearch = async (
   return data[0]
 }
 
+// Batch fetching for teia & non teia tokens on graphql
+
+const TOKEN_BATCH_CHUNK = 50
+
+const fetchHenTokensMetadata = async (tokenIds, result) => {
+  const query = `
+    query CopyrightHenTokens($tokenIds: [String!]!) {
+      tokens(
+        where: {
+          token_id: { _in: $tokenIds }
+          fa2_address: { _eq: "${HEN_CONTRACT_FA2}" }
+        }
+      ) {
+        ...baseTokenFields
+      }
+    }
+    ${BaseTokenFieldsFragment}
+  `
+  const res = await fetchGraphQL(query, 'CopyrightHenTokens', { tokenIds })
+  res?.data?.tokens?.forEach((t) => {
+    result.set(`${HEN_CONTRACT_FA2}:${t.token_id}`, {
+      name: t.name,
+      description: t.description,
+      displayUri: t.display_uri,
+      thumbnailUri: t.thumbnail_uri,
+      artifactUri: t.artifact_uri,
+      mimeType: t.mime_type,
+      creators: [t.artist_address],
+      editions: t.editions,
+      tags: t.tags?.map((tag) => tag.tag) || [],
+    })
+  })
+}
+
+/**
+ * Batch-fetch token metadata for the copyright pages.
+ *
+ * @param {Array<{ contract: string, tokenId: string | number }>} tokens
+ * @returns {Promise<Map<string, any>>} keyed by `${contract}:${tokenId}` -> metadata
+ */
+export const fetchTokensMetadataBatch = async (tokens = []) => {
+  const result = new Map()
+
+  const henIds = []
+  const byContract = new Map()
+  for (const { contract, tokenId } of tokens) {
+    if (contract === HEN_CONTRACT_FA2) {
+      henIds.push(String(tokenId))
+    } else {
+      if (!byContract.has(contract)) byContract.set(contract, [])
+      byContract.get(contract).push(String(tokenId))
+    }
+  }
+
+  // Expand each contract into chunked `tokenId.in=` requests.
+  const tzktChunks = []
+  for (const [contract, tokenIds] of byContract.entries()) {
+    for (let i = 0; i < tokenIds.length; i += TOKEN_BATCH_CHUNK) {
+      tzktChunks.push([contract, tokenIds.slice(i, i + TOKEN_BATCH_CHUNK)])
+    }
+  }
+
+  await Promise.all([
+    ...(henIds.length
+      ? [fetchHenTokensMetadata(henIds, result).catch(() => {})]
+      : []),
+    ...tzktChunks.map(async ([contract, tokenIds]) => {
+      try {
+        const url = `${
+          import.meta.env.VITE_TZKT_API
+        }/v1/tokens?contract=${contract}&tokenId.in=${tokenIds.join(
+          ','
+        )}&limit=${TOKEN_BATCH_CHUNK}`
+        const response = await fetch(url)
+        if (!response.ok) return
+        const data = await response.json()
+        for (const item of data) {
+          if (item?.metadata) {
+            result.set(`${contract}:${item.tokenId}`, item.metadata)
+          }
+        }
+      } catch {
+        // ignore chunk-level failures; affected cards show a placeholder
+      }
+    }),
+  ])
+
+  return result
+}
+
 export async function fetchUserCopyrights(address) {
   if (!address) return []
 


### PR DESCRIPTION
This PR is fixing the following UI Issues on the copyright marketplace

1. TzKT link to non-Teia NFTs
The “View on TzKT” link for registered works points to the API host with an incorrect path and now leads to: https://tzkt.io/{contract}/tokens/{tokenId}/metadata

2. 429 rate-limiting
Copyrights with many registered works fired one TzKT request per token, triggering 429 Too Many Requests 