### PR TITLE
Fixes two bugs in the copyright feature and overhauls the objkt Copyright tab

### DIFF
--- a/src/data/swr.js
+++ b/src/data/swr.js
@@ -669,6 +669,32 @@ export async function fetchUserCopyrights(address) {
   }
 }
 
+/**
+ * Fetch the copyright registry records connected to a specific token.
+ */
+export async function fetchTokenCopyrights(contract, tokenId) {
+  if (!contract || tokenId == null) return []
+
+  const url = `${
+    import.meta.env.VITE_TZKT_API
+  }/v1/contracts/${COPYRIGHT_CONTRACT}/bigmaps/copyrights/keys?active=true&limit=100&value.related_tezos_nfts.%5B*%5D.contract=${contract}&value.related_tezos_nfts.%5B*%5D.token_id=${tokenId}`
+
+  try {
+    const res = await fetch(url)
+    if (!res.ok) throw new Error(`TzKT API error: ${res.statusText}`)
+    const data = await res.json()
+    return data.filter((entry) =>
+      entry.value?.related_tezos_nfts?.some(
+        (nft) =>
+          nft.contract === contract && String(nft.token_id) === String(tokenId)
+      )
+    )
+  } catch (err) {
+    console.error('Failed to fetch token copyrights:', err)
+    return []
+  }
+}
+
 const clauseFilterMap = {
   reproduce: 'value.clauses.reproduce',
   broadcast: 'value.clauses.broadcast',

--- a/src/pages/copyrightmarketplace/index.tsx
+++ b/src/pages/copyrightmarketplace/index.tsx
@@ -6,7 +6,9 @@ import {
   fetchCopyrightsPaginated,
   fetchCopyrightsCount,
   fetchCreatorAliases,
+  fetchUserCopyrights,
 } from '@data/swr'
+import { useUserStore } from '@context/userStore'
 import CopyrightFilters, {
   type FilterValues,
 } from '@components/copyright/marketplace/CopyrightFilters'
@@ -44,6 +46,8 @@ export default function CopyrightMarketplace() {
   const [loadingMore, setLoadingMore] = useState(false)
   const [offset, setOffset] = useState(0)
   const [filters, setFilters] = useState<FilterValues>(INITIAL_FILTERS)
+  const [myCount, setMyCount] = useState<number | null>(null)
+  const address = useUserStore((st) => st.address)
 
   const loadData = useCallback(
     async (currentOffset: number, append: boolean) => {
@@ -93,6 +97,15 @@ export default function CopyrightMarketplace() {
     })
   }, [filters, loadData])
 
+  // Count of copyrights the connected wallet has registered
+  useEffect(() => {
+    if (!address) {
+      setMyCount(null)
+      return
+    }
+    fetchUserCopyrights(address).then((data) => setMyCount(data.length))
+  }, [address])
+
   const handleLoadMore = async () => {
     const nextOffset = offset + PAGE_SIZE
     setLoadingMore(true)
@@ -117,11 +130,11 @@ export default function CopyrightMarketplace() {
             <Button to="/copyright" shadow_box>
               Register Your Work
             </Button>
-            <span className={styles.stats}>
-              you have {totalCount} copyright{totalCount !== 1 ? 's' : ''} registered
-              {Object.values(filters).some((v) => v !== 'all') &&
-                ` (${entries.length} shown)`}
-            </span>
+            {address && myCount !== null && (
+              <span className={styles.stats}>
+                you have {myCount} copyright{myCount !== 1 ? 's' : ''} registered
+              </span>
+            )}
           </div>
         </div>
 

--- a/src/pages/objkt-display/tabs/Copyright.jsx
+++ b/src/pages/objkt-display/tabs/Copyright.jsx
@@ -2,87 +2,100 @@ import { Container } from '@atoms/layout'
 import { useEffect, useState } from 'react'
 import '../style.css'
 import { HashToURL } from '@utils'
-import { Line } from '@atoms/line'
 import { useObjktDisplayContext } from '..'
+import { fetchTokenCopyrights, fetchCreatorAliases } from '@data/swr'
 import axios from 'axios'
+import styles from './Copyright.module.scss'
+
+const CLAUSE_ROWS = [
+  ['reproduce', 'Reproduce'],
+  ['broadcast', 'Broadcast'],
+  ['publicDisplay', 'Public Display'],
+  ['createDerivativeWorks', 'Derivative Works'],
+  ['requireAttribution', 'Attribution Required'],
+  ['rightsAreTransferable', 'Transferable'],
+  ['retainCreatorRights', 'Retain Creator Rights'],
+  ['releasePublicDomain', 'Release to Public Domain'],
+]
+
+const EXCLUSIVE_LABELS = {
+  none: 'None',
+  majority: 'Majority share (50%+ editions)',
+  superMajority: 'Super-majority share (66.7%+ editions)',
+  creator: 'Creator',
+  owner: 'Owner',
+}
+
+function fmtDate(value) {
+  if (!value) return null
+  const parsed = new Date(value)
+  return isNaN(parsed.getTime())
+    ? value
+    : parsed.toLocaleDateString('en-US', {
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric',
+      })
+}
+
+function isValidUrl(string) {
+  try {
+    new URL(string)
+    return true
+  } catch (_) {
+    return false
+  }
+}
+
+/** The rights ledger — every clause as an allowed/denied row. */
+const RightsMatrix = ({ clauses }) => (
+  <div className={styles.matrix}>
+    {CLAUSE_ROWS.map(([key, label]) => {
+      const value = clauses?.[key]
+      if (typeof value !== 'boolean') return null
+      return (
+        <div className={styles.row} key={key}>
+          <span className={styles.rowLabel}>{label}</span>
+          <span className={styles.leader} />
+          <span className={value ? styles.allow : styles.deny}>
+            {value ? '✓ Allowed' : '✕ Denied'}
+          </span>
+        </div>
+      )
+    })}
+  </div>
+)
+
+/** Exclusive-rights + expiration summary shared by on-chain and custom license. */
+const LicenseFooter = ({ clauses }) => {
+  const exclusive = clauses?.exclusiveRights
+  const showExpiry = clauses?.expirationDateExists && clauses?.expirationDate
+  if (!exclusive && !showExpiry) return null
+  return (
+    <div className={styles.footer}>
+      {exclusive && (
+        <span>
+          Exclusive rights: <b>{EXCLUSIVE_LABELS[exclusive] || exclusive}</b>
+        </span>
+      )}
+      {showExpiry && (
+        <span>
+          Expires <b>{fmtDate(clauses.expirationDate)}</b>
+        </span>
+      )}
+    </div>
+  )
+}
 
 export const Copyright = () => {
-  const { nft, viewer_address } = useObjktDisplayContext()
+  const { nft } = useObjktDisplayContext()
   const [licenseData, setLicenseData] = useState(null)
-  const [isLoading, setIsLoading] = useState(true) // New loading state
-  const [hasError, setHasError] = useState(false) // New error state
-
-  const clauseLabels = {
-    reproduce: 'Right to Reproduce',
-    broadcast: 'Right to Broadcast',
-    publicDisplay: 'Right to Public Display',
-    createDerivativeWorks: 'Right to Create Derivative Works',
-    exclusiveRights: 'Exclusive Rights',
-    retainCreatorRights: 'Retain Creator Rights Even When Exclusive',
-    requireAttribution: 'Require Attribution on Use',
-    rightsAreTransferable: 'Rights are Transferable (Secondary Sales)',
-    releasePublicDomain: 'Release to Public Domain',
-    customUriEnabled: 'Custom URI Enabled',
-    customUri:
-      'Custom URI (External Terms & Works Connected To This Agreement)',
-  }
-
-  const descriptions = {
-    reproduce: {
-      true: '✅ Yes',
-      false: '🚫 No',
-    },
-    broadcast: {
-      true: '✅ Yes',
-      false: '🚫 No',
-    },
-    publicDisplay: {
-      true: '✅ Yes',
-      false: '🚫 No',
-    },
-    createDerivativeWorks: {
-      true: '✅ Yes',
-      false: '🚫 No',
-    },
-    releasePublicDomain: {
-      true: '✅ Yes',
-      false: '🚫 No',
-    },
-    customUriEnabled: {
-      true: '📝 Yes',
-      false: '🚫 No',
-    },
-    retainCreatorRights: {
-      true: '✅ Yes',
-      false: '🚫 No',
-    },
-    requireAttribution: {
-      true: '✅ Yes',
-      false: '🚫 No',
-    },
-    rightsAreTransferable: {
-      true: '✅ Yes',
-      false: '🚫 No',
-    },
-  }
-
-  const exclusiveRightsDescriptions = {
-    none: '🚫 None (No Exclusive Rights To Any Party)',
-    majority: '⚖️ Majority Share (50%+ Editions Owned = Exclusive Rights)',
-    superMajority:
-      '⚖️ Super-Majority Share (66.667%+ Editions Owned = Exclusive Rights)',
-  }
+  const [isLoading, setIsLoading] = useState(true)
+  const [hasError, setHasError] = useState(false)
+  const [copyrights, setCopyrights] = useState([])
+  const [aliases, setAliases] = useState(new Map())
 
   const url = HashToURL(nft?.right_uri, 'CDN', { size: 'raw' })
-
-  function isValidUrl(string) {
-    try {
-      new URL(string)
-      return true
-    } catch (_) {
-      return false
-    }
-  }
 
   useEffect(() => {
     if (!url) {
@@ -105,148 +118,158 @@ export const Copyright = () => {
       })
   }, [url])
 
-  if (isLoading) {
-    return <div>Loading license information...</div>
-  }
+  useEffect(() => {
+    if (!nft?.fa2_address || nft?.token_id == null) return
 
-  if (hasError || (!licenseData && !nft?.rights)) {
-    return <div>N/A or License Data Not Specified. 🚫</div>
-  }
+    fetchTokenCopyrights(nft.fa2_address, nft.token_id).then((records) => {
+      setCopyrights(records)
+      const registrars = [...new Set(records.map((r) => r.key.address))]
+      if (registrars.length) fetchCreatorAliases(registrars).then(setAliases)
+    })
+  }, [nft?.fa2_address, nft?.token_id])
 
-  const isCustomUriOnly = () => {
+  const isRegistered = copyrights.length > 0
+  const isCustom = nft?.rights === 'custom'
+  const hasPlainLicense =
+    nft?.rights && nft.rights !== 'none' && nft.rights !== 'custom'
+
+  const metadataLink = nft?.right_uri ? (
+    <a
+      href={isValidUrl(nft.right_uri) ? nft.right_uri : url}
+      target="_blank"
+      rel="noopener noreferrer"
+      className={styles.link}
+    >
+      View metadata →
+    </a>
+  ) : null
+
+  const renderMetadataLicense = () => {
+    if (isLoading && url) {
+      return <p className={styles.muted}>Loading license…</p>
+    }
+
+    if (isCustom && !hasError && licenseData) {
+      const clauses = licenseData.clauses || {}
+      return (
+        <>
+          <div className={styles.metaValue}>Custom license</div>
+          <RightsMatrix clauses={clauses} />
+          <LicenseFooter clauses={clauses} />
+          {clauses.customUriEnabled && clauses.customUri && (
+            <div className={styles.footerLinks}>
+              <a
+                href={clauses.customUri}
+                target="_blank"
+                rel="noopener noreferrer"
+                className={styles.link}
+              >
+                External terms →
+              </a>
+            </div>
+          )}
+          {clauses.addendum && (
+            <>
+              <div className={styles.subhead}>Addendum</div>
+              <p className={styles.addendum}>{clauses.addendum}</p>
+            </>
+          )}
+          {licenseData.documentText && (
+            <>
+              <div className={styles.subhead}>Full agreement</div>
+              <div className={styles.doc}>{licenseData.documentText}</div>
+            </>
+          )}
+          {metadataLink && (
+            <div className={styles.footerLinks}>{metadataLink}</div>
+          )}
+        </>
+      )
+    }
+
+    if (isCustom || hasPlainLicense) {
+      return (
+        <>
+          <div className={styles.metaValue}>{nft.rights}</div>
+          {metadataLink && (
+            <div className={styles.footerLinks}>{metadataLink}</div>
+          )}
+        </>
+      )
+    }
+
     return (
-      licenseData?.clauses?.customUriEnabled && licenseData?.clauses?.customUri
+      <p className={styles.muted}>
+        No license declared in this token&apos;s metadata.
+      </p>
     )
   }
 
   return (
-    <>
-      {nft?.rights === 'custom' && (
-        <>
-          <Container>
-            <div>
-              <h3>Custom License Info</h3>
-              <br />
-              <h4>URI to Agreement (Permanent)</h4>
-              <a href={url} target="_blank" rel="noopener noreferrer">
-                Metadata
-              </a>
-              <br />
-              <br />
-              <h4>License Details</h4>
-              <ul>
-                {licenseData?.clauses &&
-                  Object.entries(licenseData?.clauses).map(([key, value]) => {
-                    const title = clauseLabels[key]
-                    const displayValue = descriptions[key]
-                      ? descriptions[key][value]
-                      : value
-                    if (key === 'exclusiveRights') {
-                      return (
-                        <li key={key}>
-                          Exclusive Rights: {exclusiveRightsDescriptions[value]}
-                        </li>
-                      )
-                    }
-                    if (key === 'expirationDate') {
-                      return (
-                        <li key="expirationDate">
-                          Expiration Date:{' '}
-                          {value
-                            ? new Date(
-                                licenseData?.clauses?.expirationDate
-                              ).toLocaleDateString('en-US', {
-                                year: 'numeric',
-                                month: 'long',
-                                day: 'numeric',
-                              })
-                            : 'None'}
-                        </li>
-                      )
-                    }
-                    if (key === 'customUri') {
-                      const uriDisplay =
-                        licenseData?.clauses?.customUriEnabled && value ? (
-                          <a
-                            href={value}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                          >
-                            {value}
-                          </a>
-                        ) : (
-                          'None'
-                        )
-                      return (
-                        <li key={key}>
-                          {title}: {uriDisplay}
-                        </li>
-                      )
-                    }
-                    if (key === 'addendum' || key === 'expirationDateExists') {
-                      return null
-                    }
-                    return (
-                      <li key={key}>
-                        {title}: {displayValue}
-                      </li>
-                    )
-                  })}
-              </ul>
-              {licenseData?.clauses?.addendum && (
+    <Container>
+      <div className={styles.tab}>
+        <header className={styles.head}>
+          <span className={styles.eyebrow}>Teia Copyright Registry</span>
+          <span
+            className={`${styles.status} ${
+              isRegistered ? styles.statusOn : styles.statusOff
+            }`}
+          >
+            <span />
+            {isRegistered ? 'Registered on-chain' : 'Not registered'}
+          </span>
+        </header>
+
+        {copyrights.map((entry) => {
+          const registrar = entry.key.address
+          const name =
+            aliases.get(registrar) ||
+            `${registrar.slice(0, 6)}…${registrar.slice(-4)}`
+          const works = entry.value.related_tezos_nfts?.length || 0
+          return (
+            <div key={entry.id} className={styles.record}>
+              <div className={styles.recordMeta}>
+                <span>Registered by</span>
+                <a
+                  href={`/${aliases.get(registrar) || registrar}`}
+                  className={styles.registrar}
+                >
+                  {name}
+                </a>
+                <span className={styles.sep}>·</span>
+                <span>Record #{entry.key.nat}</span>
+                <span className={styles.sep}>·</span>
+                <span>
+                  {works} work{works !== 1 ? 's' : ''} covered
+                </span>
+              </div>
+
+              <RightsMatrix clauses={entry.value.clauses} />
+              <LicenseFooter clauses={entry.value.clauses} />
+
+              {entry.value.clauses.addendum && (
                 <>
-                  <h4>Addendum</h4>
-                  <p
-                    style={{
-                      whiteSpace: 'pre-wrap',
-                      wordWrap: 'break-word',
-                      overflowWrap: 'break-word',
-                    }}
-                  >
-                    {licenseData.clauses.addendum}
+                  <div className={styles.subhead}>Registrant note</div>
+                  <p className={styles.addendum}>
+                    {entry.value.clauses.addendum}
                   </p>
                 </>
               )}
+
+              <div className={styles.footerLinks}>
+                <a href="/copyrightmarketplace" className={styles.link}>
+                  View in registry →
+                </a>
+              </div>
             </div>
-          </Container>
-          <Line />
-          <br />
-          <Container>
-            <h2>Custom License Agreement</h2>
-            <pre
-              style={{
-                whiteSpace: 'pre-wrap',
-                wordWrap: 'break-word',
-                overflowWrap: 'break-word',
-              }}
-            >
-              {licenseData?.documentText || 'No license document available.'}
-            </pre>
-          </Container>
-        </>
-      )}
-      {nft?.rights && (
-        <Container>
-          <h3>License Information</h3>
-          <p>{nft?.rights}</p>
-          {nft?.right_uri && (
-            <>
-              <h4>Link to Metadata</h4>
-              <a
-                href={
-                  isValidUrl(nft?.right_uri)
-                    ? nft?.right_uri
-                    : HashToURL(nft?.right_uri, 'CDN', { size: 'raw' })
-                }
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                Metadata Link
-              </a>
-            </>
-          )}
-        </Container>
-      )}
-    </>
+          )
+        })}
+
+        <section className={styles.meta}>
+          <span className={styles.metaEyebrow}>Token metadata license</span>
+          {renderMetadataLicense()}
+        </section>
+      </div>
+    </Container>
   )
 }

--- a/src/pages/objkt-display/tabs/Copyright.module.scss
+++ b/src/pages/objkt-display/tabs/Copyright.module.scss
@@ -1,0 +1,218 @@
+@use '@styles/layout' as *;
+
+.tab {
+  font-family: var(--text-font);
+  max-width: 720px;
+  padding: 0.5rem 0 2rem;
+}
+
+/* ---- status header ---- */
+.head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.75rem 1.5rem;
+  flex-wrap: wrap;
+  padding-bottom: 0.75rem;
+  border-bottom: 1px solid var(--border-color);
+  margin-bottom: 1.5rem;
+}
+
+.eyebrow {
+  font-size: 11px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--secondary-color);
+}
+
+.status {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  font-size: 12px;
+  letter-spacing: 0.02em;
+}
+
+.dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: currentColor;
+}
+
+.statusOn {
+  color: var(--yes-vote-color);
+}
+
+.statusOff {
+  color: var(--secondary-color);
+}
+
+/* ---- verified record card ---- */
+.record {
+  border: 1px solid var(--border-color);
+  border-left: 2px solid var(--yes-vote-color);
+  border-radius: 4px;
+  background: var(--gray-0);
+  padding: 1.1rem 1.25rem;
+  margin-bottom: 1.25rem;
+}
+
+.recordMeta {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.4rem 0.55rem;
+  font-size: 12px;
+  color: var(--secondary-color);
+  margin-bottom: 1.15rem;
+}
+
+.registrar {
+  color: var(--text-color);
+  text-decoration: none;
+  border-bottom: 1px solid var(--border-color);
+
+  &:hover {
+    border-color: var(--text-color);
+  }
+}
+
+.sep {
+  color: var(--border-color);
+}
+
+/* ---- rights ledger (signature) ---- */
+.matrix {
+  display: grid;
+  grid-template-columns: 1fr;
+  column-gap: 2rem;
+  row-gap: 0.1rem;
+
+  @include respond-to('tablet') {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
+.row {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+  font-size: 12px;
+  padding: 0.28rem 0;
+}
+
+.rowLabel {
+  color: var(--secondary-color);
+  white-space: nowrap;
+}
+
+.leader {
+  flex: 1 1 auto;
+  min-width: 0.75rem;
+  align-self: center;
+  border-bottom: 1px dotted var(--border-color);
+}
+
+.allow {
+  color: var(--yes-vote-color);
+  white-space: nowrap;
+}
+
+.deny {
+  color: var(--secondary-color);
+  white-space: nowrap;
+  opacity: 0.7;
+}
+
+/* ---- record footer meta ---- */
+.footer {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem 1.5rem;
+  margin-top: 1.1rem;
+  padding-top: 0.85rem;
+  border-top: 1px solid var(--border-color);
+  font-size: 12px;
+  color: var(--secondary-color);
+
+  b {
+    color: var(--text-color);
+    font-weight: 600;
+  }
+}
+
+.footerLinks {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.25rem;
+  margin-top: 1rem;
+}
+
+.link {
+  font-size: 12px;
+  color: var(--text-color);
+  text-decoration: none;
+  border-bottom: 1px solid var(--border-color);
+
+  &:hover {
+    border-color: var(--text-color);
+  }
+}
+
+/* ---- token metadata license section ---- */
+.meta {
+  margin-top: 2rem;
+}
+
+.metaEyebrow {
+  display: block;
+  font-size: 11px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--secondary-color);
+  margin-bottom: 0.85rem;
+}
+
+.metaValue {
+  font-size: 14px;
+  color: var(--text-color);
+  word-break: break-word;
+}
+
+.muted {
+  font-size: 13px;
+  color: var(--secondary-color);
+}
+
+.doc {
+  white-space: pre-wrap;
+  word-wrap: break-word;
+  overflow-wrap: break-word;
+  font-size: 12px;
+  line-height: 1.65;
+  color: var(--secondary-color);
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  padding: 1rem;
+  margin-top: 0.85rem;
+  max-height: 360px;
+  overflow: auto;
+}
+
+.addendum {
+  font-size: 12px;
+  line-height: 1.6;
+  color: var(--text-color);
+  margin-top: 0.5rem;
+  white-space: pre-wrap;
+  word-wrap: break-word;
+  overflow-wrap: break-word;
+}
+
+.subhead {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-color);
+  margin: 1.1rem 0 0.4rem;
+}


### PR DESCRIPTION
### 1. Objkt Copyright tab didn't show registered copyrights
  `/objkt/<id>/copyright` only rendered the token's own metadata `rights`
  field. It never checked the on-chain Teia Copyright Registry, so a work
  with a real registered copyright showed nothing about it.

  - Added `fetchTokenCopyrights(contract, tokenId)` (`src/data/swr.js`),
    which queries the registry bigmap by `related_tezos_nfts` and re-checks
    the exact contract + token_id pair client-side.
  - The tab now surfaces the connected on-chain copyright(s) **above** the
    metadata license.

  ### 2. Copyright marketplace always showed "you have 0 copyrights registered"
  The label was wired to the global registry count and never read the
  connected wallet, so it was always wrong.

  - `/copyrightmarketplace` now reads the connected address and drives the
    label from `fetchUserCopyrights(address).length`.
  - The line is hidden when no wallet is connected. The global count is
    still used for pagination.

  ### 3. Copyright tab redesign
  Reworked the tab to match Teia's theme:

  - Status header, "Registered on-chain" / "Not registered".
  - Verified record card with registrar, record #, and works covered.
  - A full allowed/denied **rights ledger** for every clause, replacing the
    previous allowed-only badge row; reused for custom metadata licenses.
  - Proper empty state instead of a bare "none".