### PR TITLE
Fix channel message overflow on mobile

### DIFF
--- a/src/components/chat/MessageBubble.jsx
+++ b/src/components/chat/MessageBubble.jsx
@@ -107,7 +107,7 @@ export default function MessageBubble({
           />
         </Link>
       )}
-      <div>
+      <div className={styles.bubbleContent}>
         {!isOwn && (
           <Link to={`/tz/${msg.sender}`} className={styles.bubbleSender}>
             {senderAlias || walletPreview(msg.sender)}

--- a/src/components/chat/index.module.scss
+++ b/src/components/chat/index.module.scss
@@ -11,6 +11,11 @@
   flex-direction: row-reverse;
 }
 
+.bubbleContent {
+  min-width: 0;
+  max-width: 100%;
+}
+
 .bubbleAvatarLink {
   display: inline-flex;
   flex-shrink: 0;


### PR DESCRIPTION
The message content wrapper in MessageBubble kept the flex default min-width:auto