### PR TITLE
feat(profile): add collab filter and sort to Collabs tab

### DIFF
--- a/src/pages/profile/collabs.jsx
+++ b/src/pages/profile/collabs.jsx
@@ -1,5 +1,7 @@
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
+import useSWR from 'swr'
 import get from 'lodash/get'
+import uniqBy from 'lodash/uniqBy'
 import { gql } from 'graphql-request'
 import orderBy from 'lodash/orderBy'
 import { BaseTokenFieldsFragment } from '@data/api'
@@ -7,8 +9,13 @@ import TokenCollection from '@atoms/token-collection'
 import { useOutletContext } from 'react-router'
 import { useSearchParams } from 'react-router-dom'
 import Checkbox from '@atoms/input/Checkbox'
+import { Select } from '@atoms/select'
+import { Identicon } from '@atoms/identicons'
+import { walletPreview } from '@utils/string'
 import Filters from './filters'
 import styles from '@style'
+import filterStyles from '@components/activity/filters.module.scss'
+import layoutStyles from './collabs.module.scss'
 import {
   FILTER_ALL,
   FILTER_PRIMARY,
@@ -16,11 +23,37 @@ import {
   FILTER_NOT_FOR_SALE,
 } from '@constants'
 
-export default function Collabs() {
-  const { showRestricted, address, overrideProtections } = useOutletContext()
+const SORT_OPTIONS = [
+  { key: 'newest', label: 'Newest' },
+  { key: 'oldest', label: 'Oldest' },
+]
 
-  const [hasUnverifiedTokens, setHasUnverifiedTokens] = useState(false)
+// Switch to a searchable multi-select dropdown instead of chip style.
+const COLLAB_DROPDOWN_THRESHOLD = 3
+
+// Flatten the collab tokens out of the shareholders response.
+const flattenCollabTokens = (data) =>
+  (data?.teia_shareholders || [])
+    .map((shareholder) => get(shareholder, 'split_contract.created_tokens', []))
+    .flat()
+
+// Remount the feed when the profile changes.
+export default function Collabs() {
+  const context = useOutletContext()
+  return <CollabsFeed key={context.address} {...context} />
+}
+
+function CollabsFeed({ showRestricted, address, overrideProtections }) {
   const [showUnverified, setShowUnverified] = useState(false)
+
+  // Collab filter + sort
+  const [collabFilter, setCollabFilter] = useState([])
+  const [sortMode, setSortMode] = useState('newest')
+
+  const toggleCollab = (addr) =>
+    setCollabFilter((prev) =>
+      prev.includes(addr) ? prev.filter((a) => a !== addr) : [...prev, addr]
+    )
 
   const [searchParams, setSearchParams] = useSearchParams()
   const filter = searchParams.get('filter') || FILTER_ALL
@@ -35,6 +68,34 @@ export default function Collabs() {
       { preventScrollReset: true }
     )
 
+  // Read the feed's cached response. TokenCollection owns the fetch; sharing its
+  // SWR cache by reusing the same key ([namespace, ...swrParams])
+  const { data } = useSWR(['collabs', address])
+
+  const hasUnverifiedTokens = flattenCollabTokens(data).some(
+    (token) => !get(token, 'teia_meta.is_signed')
+  )
+
+  const collabOptions = useMemo(() => {
+    const tokens = flattenCollabTokens(data)
+    return uniqBy(
+      tokens.filter((token) => token.artist_address),
+      'artist_address'
+    ).map((token) => ({
+      address: token.artist_address,
+      name:
+        get(token, 'artist_profile.name') ||
+        walletPreview(token.artist_address),
+      logo: get(token, 'artist_profile.metadata.data.identicon'),
+    }))
+  }, [data])
+
+  const collabSelectOptions = collabOptions.map((c) => ({
+    value: c.address,
+    label: c.name,
+    logo: c.logo,
+  }))
+
   return (
     <>
       <Filters
@@ -47,6 +108,88 @@ export default function Collabs() {
           { type: FILTER_NOT_FOR_SALE, label: 'Not for sale' },
         ]}
       />
+
+      <div className={layoutStyles.controls}>
+        {collabOptions.length > 1 && (
+          <div className={layoutStyles.collabControl}>
+            {collabOptions.length > COLLAB_DROPDOWN_THRESHOLD ? (
+              <Select
+                label="Filter by collab"
+                alt="Filter by collab"
+                search
+                isMulti
+                closeMenuOnSelect={false}
+                placeholder="All collabs"
+                options={collabSelectOptions}
+                value={collabSelectOptions.filter((o) =>
+                  collabFilter.includes(o.value)
+                )}
+                onChange={(selected) =>
+                  setCollabFilter((selected || []).map((o) => o.value))
+                }
+                formatOptionLabel={(option, { context }) =>
+                  context === 'menu' ? (
+                    <span className={layoutStyles.optionRow}>
+                      <Identicon
+                        address={option.value}
+                        logo={option.logo}
+                        className={layoutStyles.optionAvatar}
+                      />
+                      {option.label}
+                    </span>
+                  ) : (
+                    option.label
+                  )
+                }
+              />
+            ) : (
+              <div
+                className={filterStyles.filters}
+                style={{ margin: 0, justifyContent: 'flex-start' }}
+              >
+                <button
+                  type="button"
+                  className={`${filterStyles.chip} ${
+                    collabFilter.length === 0 ? filterStyles.chip_active : ''
+                  }`}
+                  onClick={() => setCollabFilter([])}
+                >
+                  All
+                </button>
+                {collabOptions.map((c) => (
+                  <button
+                    key={c.address}
+                    type="button"
+                    className={`${filterStyles.chip} ${
+                      collabFilter.includes(c.address)
+                        ? filterStyles.chip_active
+                        : ''
+                    }`}
+                    onClick={() => toggleCollab(c.address)}
+                  >
+                    {c.name}
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
+        )}
+
+        <div className={`${filterStyles.filters} ${layoutStyles.sort}`}>
+          {SORT_OPTIONS.map((s) => (
+            <button
+              key={s.key}
+              type="button"
+              className={`${filterStyles.chip} ${
+                sortMode === s.key ? filterStyles.chip_active : ''
+              }`}
+              onClick={() => setSortMode(s.key)}
+            >
+              {s.label}
+            </button>
+          ))}
+        </div>
+      </div>
 
       {hasUnverifiedTokens ? (
         <div className={styles.tools}>
@@ -88,21 +231,19 @@ export default function Collabs() {
           return tokens
         }}
         extractTokensFromResponse={(data, { postProcessTokens }) => {
-          const tokens = data.teia_shareholders
-            .map((shareholder) => {
-              return get(shareholder, 'split_contract.created_tokens', [])
-            })
-            .flat()
-
-          setHasUnverifiedTokens(
-            tokens.some((token) => !get(token, 'teia_meta.is_signed'))
-          )
-
           return postProcessTokens(
-            orderBy(tokens, ['minted_at'])
-              .reverse()
+            orderBy(
+              flattenCollabTokens(data),
+              ['minted_at'],
+              [sortMode === 'newest' ? 'desc' : 'asc']
+            )
               .filter(
                 (token) => showUnverified || get(token, 'teia_meta.is_signed')
+              )
+              .filter(
+                (token) =>
+                  collabFilter.length === 0 ||
+                  collabFilter.includes(token.artist_address)
               )
               .map((token) => ({ ...token, key: token.token_id }))
           )
@@ -119,6 +260,11 @@ export default function Collabs() {
               split_contract {
                 created_tokens(where: { editions: { _gt: "0" } }) {
                   ...baseTokenFields
+                  artist_profile {
+                    metadata {
+                      data
+                    }
+                  }
                   listings(
                     where: { status: { _eq: "active" } }
                     order_by: { price: asc }

--- a/src/pages/profile/collabs.module.scss
+++ b/src/pages/profile/collabs.module.scss
@@ -1,0 +1,53 @@
+@use '@styles/layout' as *;
+
+.controls {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+  width: 100%;
+
+  @include respond-to('tablet') {
+    flex-direction: row;
+    align-items: flex-end;
+    justify-content: center;
+    flex-wrap: nowrap;
+    gap: 1rem 1.5rem;
+  }
+}
+
+.collabControl {
+  width: 100%;
+  min-width: 0;
+
+  @include respond-to('tablet') {
+    width: auto;
+    flex: 1 1 480px;
+    max-width: 480px;
+  }
+}
+
+.sort {
+  margin: 0;
+
+  @include respond-to('tablet') {
+    flex-shrink: 0;
+  }
+}
+
+.optionRow {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+
+.optionAvatar {
+  width: 22px;
+  height: 22px;
+  min-width: 22px;
+  border-radius: 3px;
+  object-fit: cover;
+  flex-shrink: 0;
+}


### PR DESCRIPTION
Adds a filter/sort control row to the profile Collabs feed:

- Filter by collab: multi-select over the distinct split contracts the artist participates in. Renders as Activity-style chips, switching to a searchable multi-select dropdown (with collab identicons) once there are more than a few collabs.
- Sort by Newest / Oldest (minted_at).
- Collab options and the unverified-OBJKTs flag are derived from the feed's shared SWR cache via useMemo.