### PR TITLE
Fix hidden channels still showing on public channels page

### DIFF
--- a/src/data/messaging/channel-types.ts
+++ b/src/data/messaging/channel-types.ts
@@ -37,7 +37,8 @@ export interface ChannelAdminsUpdatedEvent {
 
 export interface ChannelHiddenEvent {
   channel_id: string
-  hidden_by: string
+  hidden: boolean
+  updated_by: string
 }
 
 export interface MessagePostedEvent {

--- a/src/data/messaging/channels.ts
+++ b/src/data/messaging/channels.ts
@@ -131,10 +131,14 @@ export function useChannelList() {
         fetchAllEvents<ChannelCreatedEvent>(CONTRACT, 'channel_created'),
         fetchAllEvents<ChannelConfiguredEvent>(CONTRACT, 'channel_configured'),
         fetchAllEvents<ChannelUpdatedEvent>(CONTRACT, 'channel_updated'),
-        fetchAllEvents<ChannelHiddenEvent>(CONTRACT, 'channel_hidden'),
+        fetchAllEvents<ChannelHiddenEvent>(CONTRACT, 'channel_hidden_set'),
       ])
 
-      const hiddenIds = new Set(hidden.map((e) => e.payload.channel_id))
+      const hiddenIds = new Set<string>()
+      for (const e of hidden) {
+        if (e.payload.hidden) hiddenIds.add(e.payload.channel_id)
+        else hiddenIds.delete(e.payload.channel_id)
+      }
 
       const latestConfig: Record<string, ChannelConfiguredEvent> = {}
       for (const e of configured) {
@@ -197,12 +201,16 @@ export function useMyInbox(viewerAddress: string | undefined) {
             CONTRACT,
             'channel_admins_updated'
           ),
-          fetchAllEvents<ChannelHiddenEvent>(CONTRACT, 'channel_hidden'),
+          fetchAllEvents<ChannelHiddenEvent>(CONTRACT, 'channel_hidden_set'),
           fetchAllEvents<ChannelConfiguredEvent>(CONTRACT, 'channel_configured'),
           fetchAllEvents<ChannelUpdatedEvent>(CONTRACT, 'channel_updated'),
         ])
 
-      const hiddenIds = new Set(hidden.map((e) => e.payload.channel_id))
+      const hiddenIds = new Set<string>()
+      for (const e of hidden) {
+        if (e.payload.hidden) hiddenIds.add(e.payload.channel_id)
+        else hiddenIds.delete(e.payload.channel_id)
+      }
 
       const adminsByChannel: Record<string, Set<string>> = {}
       for (const e of created) {


### PR DESCRIPTION
Update Channel hidden filter in useChannelList/useMyInbox, the contract emits channel_hidden_set events, not channel_hidden

Also replay the events as a toggle (latest hidden state wins) instead of treating any event as permanently hidden, and fix ChannelHiddenEvent to match the real payload shape.