### PR TITLE
Let people list OBJKTs for low and 0 tez prices - updates error message and filters

### DIFF
--- a/src/atoms/input/Input.tsx
+++ b/src/atoms/input/Input.tsx
@@ -112,7 +112,7 @@ function Input(
           max={max}
           maxLength={maxlength}
           defaultValue={defaultValue}
-          value={value || ''}
+          value={value ?? ''}
           onChange={handleInput}
           onBlur={onBlur}
           pattern={pattern}

--- a/src/components/post-mint/PostMintSwapFields.jsx
+++ b/src/components/post-mint/PostMintSwapFields.jsx
@@ -6,7 +6,7 @@ import { useUserStore } from '@context/userStore'
 import { useMintStore } from '@context/mintStore'
 import {
   SWAP_TEIA_FEE_DISCLOSURE,
-  maybeWarnLowSwapPrice,
+  SWAP_ZERO_PRICE_GAS_NOTICE,
   clampSwapAmountOnBlur,
   clampSwapPriceOnBlur,
 } from '@utils/postMintSwap'
@@ -31,8 +31,9 @@ export function PostMintSwapFields({
       show(`Please enter an OBJKT quantity to swap (current value: ${amount})`)
       return
     }
-    if (price == null || price < 0) {
-      show(`Please enter a price for the swap (current value: ${price})`)
+    // A blank price must not silently become a free listing now that 0 is allowed.
+    if (price === '' || price == null || price < 0) {
+      show(`Please enter a price for the swap (0 ꜩ is allowed)`)
       return
     }
     // Same scale as Swap tab (`nft.royalties_total / 1000`) and mint_OBJKT (`royalties * 10`).
@@ -77,14 +78,13 @@ export function PostMintSwapFields({
         initial={0}
         onChange={(v) => setPrice(v === '' ? '' : v)}
         onBlur={() => {
-          setPrice((prev) => {
-            const val = clampSwapPriceOnBlur(prev)
-            maybeWarnLowSwapPrice(show, val)
-            return val
-          })
+          setPrice((prev) => clampSwapPriceOnBlur(prev))
         }}
         disabled={progress}
       />
+      {price !== '' && Number(price) === 0 && (
+        <p style={{ fontSize: '0.9em' }}>{SWAP_ZERO_PRICE_GAS_NOTICE}</p>
+      )}
       <Button
         shadow_box
         onClick={handleSubmit}

--- a/src/pages/objkt-display/tabs/Swap.jsx
+++ b/src/pages/objkt-display/tabs/Swap.jsx
@@ -10,7 +10,7 @@ import { useUserStore } from '@context/userStore'
 import { useObjktDisplayContext } from '..'
 import {
   SWAP_TEIA_FEE_DISCLOSURE,
-  maybeWarnLowSwapPrice,
+  SWAP_ZERO_PRICE_GAS_NOTICE,
   clampSwapAmountOnBlur,
   clampSwapPriceOnBlur,
 } from '@utils/postMintSwap'
@@ -43,11 +43,6 @@ export const Swap = () => {
 
   const onChange = (e) => setCurrency(e.target.value)
 
-  const checkPrice = (value) => {
-    console.debug(value)
-    maybeWarnLowSwapPrice(show, value)
-  }
-
   const proxyAdminAddress = nft.artist_profile?.is_split
     ? nft.artist_profile.split_contract.administrator_address
     : null
@@ -71,8 +66,9 @@ export const Swap = () => {
       return
     }
 
-    if (price == null || price < 0) {
-      show(`Please enter a price for the swap (current value: ${price})`)
+    // A blank price must not silently become a free listing now that 0 is allowed.
+    if (price === '' || price == null || price < 0) {
+      show(`Please enter a price for the swap (0 ꜩ is allowed)`)
       return
     }
 
@@ -139,12 +135,13 @@ export const Swap = () => {
                     initial={0}
                     onChange={setPrice}
                     onBlur={(e) => {
-                      const val = clampSwapPriceOnBlur(e.target.value)
-                      setPrice(val)
-                      checkPrice(val)
+                      setPrice(clampSwapPriceOnBlur(e.target.value))
                     }}
                     disabled={progress}
                   />
+                  {price !== '' && Number(price) === 0 && (
+                    <p>{SWAP_ZERO_PRICE_GAS_NOTICE}</p>
+                  )}
                 </div>
               </div>
               <Button shadow_box onClick={handleSubmit} fit disabled={progress}>

--- a/src/utils/postMintSwap.js
+++ b/src/utils/postMintSwap.js
@@ -7,20 +7,12 @@ export const SWAP_TEIA_FEE_DISCLOSURE =
 export const POST_MINT_SUSTAIN_TEIA =
   'Please help sustain Teia, swap your new OBJKT on Teia:'
 
-const PRICE_MAX = 1e6
-const LOW_PRICE_WARN_THRESHOLD = 0.1
+export const SWAP_ZERO_PRICE_GAS_NOTICE =
+  'Listing for 0 ꜩ makes this OBJKT free to collect, but Tezos network ' +
+  'fees still apply: you pay them to list it, and collectors pay them to ' +
+  'collect it.'
 
-/**
- * @param {(title: string, message?: string) => void} showModal
- * @param {number} value
- */
-export function maybeWarnLowSwapPrice(showModal, value) {
-  if (value <= LOW_PRICE_WARN_THRESHOLD) {
-    showModal(
-      `Price is really low (${value}ꜩ), for giveaways checkout hicetdono (dono.xtz.tools)`
-    )
-  }
-}
+const PRICE_MAX = 1e6
 
 /**
  * @param {unknown} raw


### PR DESCRIPTION
Two things stopped low-priced swaps, one in the input and one on submit.

The shared Input rendered `value || ''`, so a numeric 0 showed as an empty field. Typing 0 cleared it, and a 0 price could never be seen or entered. It now uses `??`, which only changes what a real 0 displays; no other number input starts at 0.

Leaving the price field at 0.1 tez or less opened the "for giveaways checkout hicetdono" modal. While a modal is open the Swap tab replaces the whole form, and since clicking Swap is what blurs the price field, the button unmounted before the click landed. Low prices could not be submitted at all. The warning and its arbitrary 0.1 threshold are gone.

The marketplace contract has always accepted these: it already holds 1,432 listings at 0 tez and 4,546 under 0.1.

In their place, a price of exactly 0 shows an inline note that network fees still apply to listing and collecting. It is inline rather than a modal because a modal is what hid the form.

A blank price used to submit silently as a 0 tez listing. Now that 0 is a deliberate choice, blank is rejected with a prompt saying 0 is allowed, so nobody lists for free by accident.

The post-mint swap form shared the same helpers and gets the same changes.